### PR TITLE
dts: riscv: telink: telink_b91.dtsi: Fix OpenThread subsystem for Tel…

### DIFF
--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -159,6 +159,7 @@
 
 		ieee802154: ieee802154@80140800 {
 			compatible = "telink,b91-zb";
+			label = "IEEE802154_b91";
 			reg = <0x80140800 0x800>;
 			interrupt-parent = <&plic0>;
 			interrupts = <15 2>;

--- a/west.yml
+++ b/west.yml
@@ -129,6 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_telink
+      url: https://github.com/telink-semi/hal_telink
       revision: 97090d1ad4218c3939507824485302846a1c85f7
       path: modules/hal/telink
       submodules: true


### PR DESCRIPTION
Telink b91 OpenThread sample projects fail due to NULL device binding.
Kconfig provides NET_CONFIG_IEEE802154_DEV_NAME equal to "IEEE802154_b91",
but device tree has no label.