### PR TITLE
samples: sensors: mpu6050: boards: Added tlsr9518adk80d support

### DIFF
--- a/samples/sensor/mpu6050/boards/tlsr9518adk80d.overlay
+++ b/samples/sensor/mpu6050/boards/tlsr9518adk80d.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c {
+	mpu6050@68 {
+		compatible = "invensense,mpu6050";
+		reg = <0x68>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Added the tlsr9518adk80d.overlay for mpu6050 sensor.

Signed-off-by: Misha Tkachenko <misha.tkachenko@telink-semi.com>