### PR TITLE
drivers: hwinfo: Kconfig

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE          hwinfo_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO             hwinfo_weak_impl.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SHELL       hwinfo_shell.c)
 
+zephyr_library_sources_ifdef(CONFIG_HWINFO_TELINK_B91  hwinfo_b91.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_ESP32       hwinfo_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_GECKO       hwinfo_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_IMXRT       hwinfo_imxrt.c)

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -145,3 +145,10 @@ config HWINFO_GECKO
 	  Enable Silabs GECKO hwinfo driver.
 
 endif
+
+config HWINFO_TELINK_B91
+	bool "Telink B91 device ID"
+	default y
+	depends on SOC_RISCV_TELINK_B91
+	help
+	  Enable Telink B91 hwinfo driver.

--- a/drivers/hwinfo/hwinfo_b91.c
+++ b/drivers/hwinfo/hwinfo_b91.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/hwinfo.h>
 #include <string.h>
+#include <flash.h>
 
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {


### PR DESCRIPTION
Added the selector for Telink B91 platform.

Signed-off-by: Misha Tkachenko <misha.tkachenko@telink-semi.com>