### PR TITLE
soc: riscv: telink_b91: Use power management policy

### DIFF
--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -903,19 +903,16 @@ static struct ieee802154_radio_api b91_radio_api = {
 static int ieee802154_b91_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	ARG_UNUSED(dev);
-	extern volatile bool telink_b91_pm_suspend_entered;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (telink_b91_pm_suspend_entered) {
-			/* restart radio */
-			rf_mode_init();
-			rf_set_zigbee_250K_mode();
-			rf_set_chn(B91_LOGIC_CHANNEL_TO_PHYSICAL(data.current_channel));
-			rf_set_power_level(b91_tx_pwr_lt[data.current_dbm - B91_TX_POWER_MIN]);
-			rf_set_txmode();
-			rf_set_rxmode();
-		}
+		/* restart radio */
+		rf_mode_init();
+		rf_set_zigbee_250K_mode();
+		rf_set_chn(B91_LOGIC_CHANNEL_TO_PHYSICAL(data.current_channel));
+		rf_set_power_level(b91_tx_pwr_lt[data.current_dbm - B91_TX_POWER_MIN]);
+		rf_set_txmode();
+		rf_set_rxmode();
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:

--- a/drivers/ieee802154/ieee802154_b91.h
+++ b/drivers/ieee802154/ieee802154_b91.h
@@ -136,6 +136,9 @@ struct b91_data {
 	int16_t current_dbm;
 	volatile bool ack_sending;
 	struct b91_src_match_table *src_match_table;
+#ifdef CONFIG_PM_DEVICE
+	atomic_t current_pm_lock;
+#endif /* CONFIG_PM_DEVICE */
 };
 
 #endif

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -538,16 +538,13 @@ static int uart_b91_pm_action(const struct device *dev, enum pm_device_action ac
 {
 	volatile struct uart_b91_t *uart = GET_UART(dev);
 	struct uart_b91_data *data = dev->data;
-	extern volatile bool telink_b91_pm_suspend_entered;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (telink_b91_pm_suspend_entered) {
-			/* reset TX/RX byte index */
-			data->tx_byte_index = 0;
-			data->rx_byte_index = 0;
-			uart->status |= UART_RX_RESET_BIT | UART_TX_RESET_BIT;
-		}
+		/* reset TX/RX byte index */
+		data->tx_byte_index = 0;
+		data->rx_byte_index = 0;
+		uart->status |= UART_RX_RESET_BIT | UART_TX_RESET_BIT;
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:

--- a/soc/riscv/riscv-privilege/telink_b91/power.c
+++ b/soc/riscv/riscv-privilege/telink_b91/power.c
@@ -90,11 +90,6 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		LOG_DBG("Sleep Time = 0 or less\n");
 		return;
 	}
-#ifdef CONFIG_PM_DEVICE
-	if (pm_device_is_any_busy()) {
-		return;
-	}
-#endif /* CONFIG_PM_DEVICE */
 
 	uint64_t stimer_sleep_ticks = mticks_to_systicks(wakeup_time - current_time);
 

--- a/soc/riscv/riscv-privilege/telink_b91/power.c
+++ b/soc/riscv/riscv-privilege/telink_b91/power.c
@@ -7,7 +7,6 @@
 #include <ext_driver/ext_pm.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/pm.h>
-#include <zephyr/pm/device.h>
 #include <stimer.h>
 #include <zephyr/zephyr.h>
 
@@ -71,10 +70,6 @@ static void set_mtime(uint64_t time)
 	*rl = (uint32_t)time;
 }
 
-#ifdef CONFIG_PM_DEVICE
-volatile bool telink_b91_pm_suspend_entered;
-#endif /* CONFIG_PM_DEVICE */
-
 /**
  * @brief PM state set API implementation.
  */
@@ -103,9 +98,6 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			}
 			cpu_sleep_wakeup_32k_rc(SUSPEND_MODE, PM_WAKEUP_TIMER,
 						tl_sleep_tick + stimer_sleep_ticks);
-#ifdef CONFIG_PM_DEVICE
-			telink_b91_pm_suspend_entered = true;
-#endif
 			current_time += systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
 			set_mtime(current_time);
 		}
@@ -126,15 +118,6 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(state);
 	ARG_UNUSED(substate_id);
 
-	switch (state) {
-	case PM_STATE_SUSPEND_TO_IDLE:
-#ifdef CONFIG_PM_DEVICE
-		telink_b91_pm_suspend_entered = false;
-#endif
-		break;
-	default:
-		break;
-	}
 	/*
 	 * System is now in active mode. Enabling interrupts which were
 	 * disabled when OS started idle code.


### PR DESCRIPTION
Replace device locking and checking if any device is locked from idle
with using power management policy.

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>