### PR TITLE
driver: telink: gpio isr table offset fix

### DIFF
--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -96,6 +96,8 @@ static inline void gpiob_b91_irq_en_set(const struct device *dev, gpio_pin_t pin
 
 	volatile struct gpio_b91_t *gpio = GET_GPIO(dev);
 
+	irq -= CONFIG_2ND_LVL_ISR_TBL_OFFSET;
+
 	if (irq == IRQ_GPIO) {
 		BM_SET(gpio->irq_en, BIT(pin));
 	} else if (irq == IRQ_GPIO2_RISC0) {
@@ -113,6 +115,8 @@ static inline void gpiob_b91_irq_en_clr(const struct device *dev, gpio_pin_t pin
 	uint8_t irq = GET_IRQ_NUM(dev);
 	volatile struct gpio_b91_t *gpio = GET_GPIO(dev);
 
+	irq -= CONFIG_2ND_LVL_ISR_TBL_OFFSET;
+
 	if (irq == IRQ_GPIO) {
 		BM_CLR(gpio->irq_en, BIT(pin));
 	} else if (irq == IRQ_GPIO2_RISC0) {
@@ -129,6 +133,8 @@ static inline uint8_t gpio_b91_irq_en_get(const struct device *dev)
 	uint8_t irq = GET_IRQ_NUM(dev);
 	volatile struct gpio_b91_t *gpio = GET_GPIO(dev);
 
+	irq -= CONFIG_2ND_LVL_ISR_TBL_OFFSET;
+
 	if (irq == IRQ_GPIO) {
 		status = gpio->irq_en;
 	} else if (irq == IRQ_GPIO2_RISC0) {
@@ -144,6 +150,8 @@ static inline uint8_t gpio_b91_irq_en_get(const struct device *dev)
 static inline void gpio_b91_irq_status_clr(uint8_t irq)
 {
 	gpio_irq_status_e status = 0;
+
+	irq -= CONFIG_2ND_LVL_ISR_TBL_OFFSET;
 
 	if (irq == IRQ_GPIO) {
 		status = FLD_GPIO_IRQ_CLR;
@@ -165,6 +173,8 @@ void gpio_b91_irq_set(const struct device *dev, gpio_pin_t pin,
 	uint8_t irq_num = GET_IRQ_NUM(dev);
 	uint8_t irq_prioriy = GET_IRQ_PRIORITY(dev);
 	volatile struct gpio_b91_t *gpio = GET_GPIO(dev);
+
+	irq_num -= CONFIG_2ND_LVL_ISR_TBL_OFFSET;
 
 	/* Get level and mask based on IRQ number */
 	if (irq_num == IRQ_GPIO) {

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -604,8 +604,9 @@ static int b91_init(const struct device *dev)
 
 	/* init IRQs */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), b91_rf_isr, 0, 0);
-	riscv_plic_irq_enable(DT_INST_IRQN(0));
-	riscv_plic_set_priority(DT_INST_IRQN(0), DT_INST_IRQ(0, priority));
+	riscv_plic_irq_enable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
+	riscv_plic_set_priority(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET,
+				DT_INST_IRQ(0, priority));
 	rf_set_irq_mask(FLD_RF_IRQ_RX | FLD_RF_IRQ_TX);
 
 	/* init data variables */
@@ -730,7 +731,7 @@ static int b91_start(const struct device *dev)
 		rf_set_txmode();
 		rf_set_rxmode();
 		delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
-		riscv_plic_irq_enable(DT_INST_IRQN(0));
+		riscv_plic_irq_enable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
 		data.is_started = true;
 	}
 
@@ -747,7 +748,7 @@ static int b91_stop(const struct device *dev)
 				data.ack_sending = false;
 			}
 		}
-		riscv_plic_irq_disable(DT_INST_IRQN(0));
+		riscv_plic_irq_disable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
 		rf_set_tx_rx_off();
 		delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
 		data.is_started = false;
@@ -847,7 +848,7 @@ static int b91_configure(const struct device *dev,
 		}
 		break;
 	case IEEE802154_CONFIG_ACK_FPB:
-		riscv_plic_irq_disable(DT_INST_IRQN(0));
+		riscv_plic_irq_disable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
 		if (config->ack_fpb.addr) {
 			if (config->ack_fpb.enabled) {
 				b91_src_match_table_add(b91->src_match_table,
@@ -862,7 +863,7 @@ static int b91_configure(const struct device *dev,
 		} else {
 			result = -ENOTSUP;
 		}
-		riscv_plic_irq_enable(DT_INST_IRQN(0));
+		riscv_plic_irq_enable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
 		break;
 #endif /* CONFIG_OPENTHREAD_FTD */
 	default:

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -616,8 +616,9 @@ static const struct uart_driver_api uart_b91_driver_api = {
 			    uart_b91_irq_handler,				    \
 			    DEVICE_DT_INST_GET(n), 0);				    \
 										    \
-		riscv_plic_irq_enable(DT_INST_IRQN(n));				    \
-		riscv_plic_set_priority(DT_INST_IRQN(n), DT_INST_IRQ(n, priority)); \
+		riscv_plic_irq_enable(DT_INST_IRQN(n) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);	\
+		riscv_plic_set_priority(DT_INST_IRQN(n) - CONFIG_2ND_LVL_ISR_TBL_OFFSET,\
+		DT_INST_IRQ(n, priority)); \
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(UART_B91_INIT)

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -82,7 +82,7 @@
 			compatible = "telink,b91-gpio";
 			gpio-controller;
 			interrupt-parent = <&plic0>;
-			interrupts = <25 1>, <26 1>, <27 1>;
+			interrupts = <37 1>, <38 1>, <39 1>;
 			reg = <0x80140300 0x08>;
 			status = "disabled";
 			#gpio-cells = <2>;
@@ -92,7 +92,7 @@
 			compatible = "telink,b91-gpio";
 			gpio-controller;
 			interrupt-parent = <&plic0>;
-			interrupts = <25 1>, <26 1>, <27 1>;
+			interrupts = <37 1>, <38 1>, <39 1>;
 			reg = <0x80140308 0x08>;
 			status = "disabled";
 			#gpio-cells = <2>;
@@ -102,7 +102,7 @@
 			compatible = "telink,b91-gpio";
 			gpio-controller;
 			interrupt-parent = <&plic0>;
-			interrupts = <25 1>, <26 1>, <27 1>;
+			interrupts = <37 1>, <38 1>, <39 1>;
 			reg = <0x80140310 0x08>;
 			status = "disabled";
 			#gpio-cells = <2>;
@@ -112,7 +112,7 @@
 			compatible = "telink,b91-gpio";
 			gpio-controller;
 			interrupt-parent = <&plic0>;
-			interrupts = <25 1>, <26 1>, <27 1>;
+			interrupts = <37 1>, <38 1>, <39 1>;
 			reg = <0x80140318 0x08>;
 			status = "disabled";
 			#gpio-cells = <2>;
@@ -122,7 +122,7 @@
 			compatible = "telink,b91-gpio";
 			gpio-controller;
 			interrupt-parent = <&plic0>;
-			interrupts = <25 1>, <26 1>, <27 1>;
+			interrupts = <37 1>, <38 1>, <39 1>;
 			reg = <0x80140320 0x08>;
 			status = "disabled";
 			#gpio-cells = <2>;
@@ -144,7 +144,7 @@
 		uart0: serial@80140080 {
 			compatible = "telink,b91-uart";
 			reg = <0x80140080 0x40>;
-			interrupts = <19 1>;
+			interrupts = <31 1>;
 			interrupt-parent = <&plic0>;
 			status = "disabled";
 		};
@@ -152,7 +152,7 @@
 		uart1: serial@801400C0 {
 			compatible = "telink,b91-uart";
 			reg = <0x801400C0 0x40>;
-			interrupts = <18 1>;
+			interrupts = <30 1>;
 			interrupt-parent = <&plic0>;
 			status = "disabled";
 		};
@@ -162,7 +162,7 @@
 			label = "IEEE802154_b91";
 			reg = <0x80140800 0x800>;
 			interrupt-parent = <&plic0>;
-			interrupts = <15 2>;
+			interrupts = <27 2>;
 			status = "disabled";
 		};
 

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
@@ -29,7 +29,11 @@ config RISCV_GP
 
 config NUM_IRQS
 	int
-	default 64
+	default 76
+
+config 2ND_LVL_ISR_TBL_OFFSET
+	int
+	default 12
 
 config PINCTRL
 	default y

--- a/west.yml
+++ b/west.yml
@@ -130,7 +130,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 922be7281d9d4eb4318ca5c7323ae3b4f73b6ea6
+      revision: a6343263a2c6bef2885f7ef2f23c92a3cb8cd282
       path: modules/hal/telink
       submodules: true
       groups:


### PR DESCRIPTION
Fixed incorrect offset in _sw_isr_table for Level 2 Interrupts.

Signed-off-by: Dmytro Huz <diman1436@gmail.com>