### PR TITLE
soc: riscv: telink_b91: Parse IEEE802.15.4 frame version 2015

### DIFF
--- a/drivers/ieee802154/Kconfig.b91
+++ b/drivers/ieee802154/Kconfig.b91
@@ -66,5 +66,12 @@ config IEEE802154_B91_MAC7
 	help
 	  This is the byte 7 of the MAC address.
 
+config IEEE802154_B91_DELAY_TRX_ACC
+	int "Clock accuracy for delayed operations"
+	default 20
+	help
+	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
+	  or delayed reception), in ppm.
+
 endif # ! IEEE802154_B91_RANDOM_MAC
 endif # IEEE802154_TELINK_B91

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -30,6 +30,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "ieee802154_b91.h"
 
+#include "ieee802154_b91_frame.c"
+
 
 #ifdef CONFIG_OPENTHREAD_FTD
 /* B91 radio source match table structure */
@@ -42,54 +44,6 @@ static struct  b91_data data = {
 	.src_match_table = &src_match_table
 #endif /* CONFIG_OPENTHREAD_FTD */
 };
-
-/*
- * Check if received buffer contains destination PANID
- * buffer should be valid and contains at lest 2 bytes
- */
-static bool b91_is_dest_panid_present(const uint8_t fcb[2])
-{
-	bool result = true;
-	const uint8_t frame_ver_t = fcb[1] & B91_FRAME_VER_MASK;
-	const uint8_t dst_addr_t = fcb[1] & B91_DEST_ADDR_TYPE_MASK;
-	const uint8_t src_addr_t = fcb[1] & B91_SRC_ADDR_TYPE_MASK;
-	const uint8_t panid_compr_t = fcb[0] & B91_PANID_COMPRESSION_MASK;
-
-	if (frame_ver_t == B91_FRAME_VER_2015) {
-		if ((dst_addr_t == B91_DEST_ADDR_TYPE_NA &&
-				src_addr_t == B91_SRC_ADDR_TYPE_NA &&
-				panid_compr_t == B91_PANID_COMPRESSION_OFF) ||
-			(dst_addr_t == B91_DEST_ADDR_TYPE_IEEE &&
-				src_addr_t == B91_SRC_ADDR_TYPE_NA &&
-				panid_compr_t == B91_PANID_COMPRESSION_ON) ||
-			(dst_addr_t == B91_DEST_ADDR_TYPE_SHORT &&
-				src_addr_t == B91_SRC_ADDR_TYPE_NA &&
-				panid_compr_t == B91_PANID_COMPRESSION_ON) ||
-			(dst_addr_t == B91_DEST_ADDR_TYPE_NA &&
-				src_addr_t == B91_SRC_ADDR_TYPE_IEEE &&
-				panid_compr_t == B91_PANID_COMPRESSION_OFF) ||
-			(dst_addr_t == B91_DEST_ADDR_TYPE_NA &&
-				src_addr_t == B91_SRC_ADDR_TYPE_SHORT &&
-				panid_compr_t == B91_PANID_COMPRESSION_OFF) ||
-			(dst_addr_t == B91_DEST_ADDR_TYPE_NA &&
-				src_addr_t == B91_SRC_ADDR_TYPE_IEEE &&
-				panid_compr_t == B91_PANID_COMPRESSION_ON) ||
-			(dst_addr_t == B91_DEST_ADDR_TYPE_NA &&
-				src_addr_t == B91_SRC_ADDR_TYPE_SHORT &&
-				panid_compr_t == B91_PANID_COMPRESSION_ON) ||
-			(dst_addr_t == B91_DEST_ADDR_TYPE_IEEE &&
-				src_addr_t == B91_SRC_ADDR_TYPE_IEEE &&
-				panid_compr_t == B91_PANID_COMPRESSION_ON)) {
-			result = false;
-		}
-	} else {
-		if (dst_addr_t == B91_DEST_ADDR_TYPE_NA) {
-			result = false;
-		}
-	}
-
-	return result;
-}
 
 #ifdef CONFIG_OPENTHREAD_FTD
 
@@ -108,7 +62,8 @@ static bool b91_src_match_table_search(
 	for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
 		if (table->item[i].valid && table->item[i].ext == ext &&
 			!memcmp(table->item[i].addr, addr,
-				ext ? B91_IEEE_ADDRESS_SIZE : B91_SHORT_ADDRESS_SIZE)) {
+				ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
+				IEEE802154_FRAME_LENGTH_ADDR_SHORT)) {
 			result = true;
 			break;
 		}
@@ -127,7 +82,8 @@ static void b91_src_match_table_add(
 				table->item[i].valid = true;
 				table->item[i].ext = ext;
 				memcpy(table->item[i].addr, addr,
-					ext ? B91_IEEE_ADDRESS_SIZE : B91_SHORT_ADDRESS_SIZE);
+					ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
+					IEEE802154_FRAME_LENGTH_ADDR_SHORT);
 				break;
 			}
 		}
@@ -141,11 +97,13 @@ static void b91_src_match_table_remove(
 	for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
 		if (table->item[i].valid && table->item[i].ext == ext &&
 			!memcmp(table->item[i].addr, addr,
-				ext ? B91_IEEE_ADDRESS_SIZE : B91_SHORT_ADDRESS_SIZE)) {
+				ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
+				IEEE802154_FRAME_LENGTH_ADDR_SHORT)) {
 			table->item[i].valid = false;
 			table->item[i].ext = false;
 			memset(table->item[i].addr, 0,
-				ext ? B91_IEEE_ADDRESS_SIZE : B91_SHORT_ADDRESS_SIZE);
+				ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
+				IEEE802154_FRAME_LENGTH_ADDR_SHORT);
 			break;
 		}
 	}
@@ -159,116 +117,30 @@ static void b91_src_match_table_remove_group(struct b91_src_match_table *table, 
 			table->item[i].valid = false;
 			table->item[i].ext = false;
 			memset(table->item[i].addr, 0,
-				ext ? B91_IEEE_ADDRESS_SIZE : B91_SHORT_ADDRESS_SIZE);
+				ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
+				IEEE802154_FRAME_LENGTH_ADDR_SHORT);
 		}
 	}
 }
 
 /*
- * Check if received buffer contains data request
+ * Check frame possible require to set pending bit
+ * data request command or data
  * buffer should be valid
  */
-static bool b91_is_data_request(const uint8_t *buf, uint8_t size,
-	uint8_t *sn, const uint8_t **addr, bool *ext)
+static bool b91_require_pending_bit(const struct ieee802154_frame *frame)
 {
 	bool result = false;
 
-	do {
-		size_t pos = 0;
-		/* at frame control */
-		if (size < B91_PAN_ID_OFFSET) { /* FCB[2], SN[1] */
-			break;
-		}
-		*sn = buf[B91_DSN_OFFSET];
-		pos += B91_PAN_ID_OFFSET; /* FCB[2], SN[1] */
-		if ((buf[0] & B91_FRAME_TYPE_MASK) != B91_FRAME_TYPE_CMD) {
-			break;
-		}
-		/* at destination PANID */
-		if (pos + B91_PAN_ID_SIZE > size) {
-			break;
-		}
-		if (b91_is_dest_panid_present(buf)) {
-			pos += B91_PAN_ID_SIZE; /* PANID[2] */
-		}
-		/* at destination address */
-		if ((buf[1] & B91_DEST_ADDR_TYPE_MASK) == B91_DEST_ADDR_TYPE_NA) {
-			/* no destination address */
-		} else if ((buf[1] & B91_DEST_ADDR_TYPE_MASK) == B91_DEST_ADDR_TYPE_SHORT) {
-			pos += B91_SHORT_ADDRESS_SIZE; /* ADDR[2] */
-		} else if ((buf[1] & B91_DEST_ADDR_TYPE_MASK) == B91_DEST_ADDR_TYPE_IEEE) {
-			pos += B91_IEEE_ADDRESS_SIZE; /* ADDR[8] */
-		} else {
-			break;
-		}
-		/* at source PAN ID */
-		if ((buf[1] & B91_SRC_ADDR_TYPE_MASK) != B91_SRC_ADDR_TYPE_NA &&
-			(buf[0] & B91_PANID_COMPRESSION_MASK) == B91_PANID_COMPRESSION_OFF) {
-			if ((buf[1] & B91_FRAME_VER_MASK) != B91_FRAME_VER_2015 ||
-				(buf[1] & B91_DEST_ADDR_TYPE_MASK) != B91_DEST_ADDR_TYPE_IEEE ||
-				(buf[1] & B91_SRC_ADDR_TYPE_MASK) != B91_SRC_ADDR_TYPE_IEEE) {
-				pos += B91_PAN_ID_SIZE; /* PANID[2] */
+	if (frame->general.valid) {
+		if (frame->general.type == IEEE802154_FRAME_FCF_TYPE_DATA) {
+			result = true;
+		} else if (frame->general.type == IEEE802154_FRAME_FCF_TYPE_CMD && frame->data) {
+			if (frame->data[0] == B91_CMD_ID_DATA_REQ) {
+				result = true;
 			}
 		}
-		/* at source address */
-		if ((buf[1] & B91_SRC_ADDR_TYPE_MASK) == B91_SRC_ADDR_TYPE_NA) {
-			/* no source address */
-			*addr = NULL;
-		} else if ((buf[1] & B91_SRC_ADDR_TYPE_MASK) == B91_SRC_ADDR_TYPE_SHORT) {
-			*addr = &buf[pos];
-			*ext = false;
-			pos += B91_SHORT_ADDRESS_SIZE; /* ADDR[2] */
-		} else if ((buf[1] & B91_SRC_ADDR_TYPE_MASK) == B91_SRC_ADDR_TYPE_IEEE) {
-			*addr = &buf[pos];
-			*ext = true;
-			pos += B91_IEEE_ADDRESS_SIZE; /* ADDR[8] */
-		} else {
-			break;
-		}
-		if (pos >= size) {
-			break;
-		}
-		/* at security header */
-		if ((buf[0] & B91_SECURITY_EABLE_MASK) == B91_SECURITY_EABLE_ON) {
-			const uint8_t key_mode_t = buf[pos] & B91_KEY_ID_MODE_MASK;
-
-			if (key_mode_t == B91_KEY_ID_MODE_0) {
-				pos += B91_KEY_ID_MODE_0_LEN; /* SC[1], FC[4] */
-			} else if (key_mode_t == B91_KEY_ID_MODE_1) {
-				pos += B91_KEY_ID_MODE_1_LEN; /* SC[1], FC[4], KEYID[1] */
-			} else if (key_mode_t == B91_KEY_ID_MODE_2) {
-				pos += B91_KEY_ID_MODE_2_LEN; /* SC[1], FC[4], KEY[4], KEYID[1] */
-			} else if (key_mode_t == B91_KEY_ID_MODE_3) {
-				pos += B91_KEY_ID_MODE_3_LEN; /* SC[1], FC[4], KEY[8], KEYID[1] */
-			}
-		}
-		/* at IE header */
-		bool ie_error = false;
-
-		if ((buf[1] & B91_IE_PRESENT_MASK) == B91_IE_PRESENT_ON) {
-			ie_error = true;
-			while (pos + 1 < size) {
-				uint8_t ie_type =
-					((buf[pos + 1] & B91_IE_TYPE_H_MASK) << B91_IE_TYPE_H_OFS) |
-					((buf[pos] & B91_IE_TYPE_L_MASK) >> B91_IE_TYPE_L_OFS);
-				/* at IE header begin, probably not last */
-				pos += B91_IE_HEADER_SIZE + (buf[pos] & B91_IE_LEN_MASK);
-				if (ie_type == B91_IE_TYPE_TERMINATE) {
-					ie_error = false;
-					break;
-				}
-			}
-		}
-		if (ie_error || pos >= size) {
-			break;
-		}
-		/* at payload */
-		if (buf[pos] != B91_CMD_ID_DATA_REQ) {
-			break;
-		}
-		result = true;
-	} while (0);
-
+	}
 	return result;
 }
 
@@ -305,10 +177,10 @@ static void b91_enable_pm(const struct device *dev)
 /* Set filter PAN ID */
 static int b91_set_pan_id(uint16_t pan_id)
 {
-	uint8_t pan_id_le[B91_PAN_ID_SIZE];
+	uint8_t pan_id_le[IEEE802154_FRAME_LENGTH_PANID];
 
 	sys_put_le16(pan_id, pan_id_le);
-	memcpy(data.filter_pan_id, pan_id_le, B91_PAN_ID_SIZE);
+	memcpy(data.filter_pan_id, pan_id_le, IEEE802154_FRAME_LENGTH_PANID);
 
 	return 0;
 }
@@ -316,10 +188,10 @@ static int b91_set_pan_id(uint16_t pan_id)
 /* Set filter short address */
 static int b91_set_short_addr(uint16_t short_addr)
 {
-	uint8_t short_addr_le[B91_SHORT_ADDRESS_SIZE];
+	uint8_t short_addr_le[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
 
 	sys_put_le16(short_addr, short_addr_le);
-	memcpy(data.filter_short_addr, short_addr_le, B91_SHORT_ADDRESS_SIZE);
+	memcpy(data.filter_short_addr, short_addr_le, IEEE802154_FRAME_LENGTH_ADDR_SHORT);
 
 	return 0;
 }
@@ -327,57 +199,41 @@ static int b91_set_short_addr(uint16_t short_addr)
 /* Set filter IEEE address */
 static int b91_set_ieee_addr(const uint8_t *ieee_addr)
 {
-	memcpy(data.filter_ieee_addr, ieee_addr, B91_IEEE_ADDRESS_SIZE);
+	memcpy(data.filter_ieee_addr, ieee_addr, IEEE802154_FRAME_LENGTH_ADDR_EXT);
 
 	return 0;
 }
 
 /* Filter PAN ID, short address and IEEE address */
-static bool b91_run_filter(const uint8_t *buf, uint8_t size)
+static bool b91_run_filter(const struct ieee802154_frame *frame)
 {
 	bool result = false;
 
 	do {
-		size_t pos = 0;
-		/* at frame control */
-		if (buf == NULL || size < B91_PAN_ID_OFFSET) { /* FCB[2], SN[1] */
-			break;
+		if (frame->dst_panid != NULL) {
+			if (memcmp(frame->dst_panid, data.filter_pan_id,
+					IEEE802154_FRAME_LENGTH_PANID) != 0 &&
+				memcmp(frame->dst_panid, B91_BROADCAST_ADDRESS,
+					IEEE802154_FRAME_LENGTH_PANID) != 0) {
+				break;
+			}
 		}
-		pos += B91_PAN_ID_OFFSET; /* FCB[2], SN[1] */
-		/* at destination PANID */
-		if (pos + 2 > size) {
-			break;
-		}
-		if (b91_is_dest_panid_present(buf)) {
-			if (memcmp(&buf[pos], data.filter_pan_id, B91_PAN_ID_SIZE) != 0 &&
-				memcmp(&buf[pos], B91_BROADCAST_ADDRESS, B91_PAN_ID_SIZE) != 0) {
-				break;
+		if (frame->dst_addr != NULL) {
+			if (frame->dst_addr_ext) {
+				if ((net_if_get_link_addr(data.iface)->len !=
+						IEEE802154_FRAME_LENGTH_ADDR_EXT) ||
+					memcmp(frame->dst_addr, data.filter_ieee_addr,
+						IEEE802154_FRAME_LENGTH_ADDR_EXT) != 0) {
+					break;
+				}
+			} else {
+				if (memcmp(frame->dst_addr, B91_BROADCAST_ADDRESS,
+						IEEE802154_FRAME_LENGTH_ADDR_SHORT) != 0 &&
+					memcmp(frame->dst_addr, data.filter_short_addr,
+						IEEE802154_FRAME_LENGTH_ADDR_SHORT) != 0) {
+					break;
+				}
 			}
-			pos += B91_PAN_ID_SIZE; /* PANID[2] */
-		}
-		/* at destination address */
-		if ((buf[1] & B91_DEST_ADDR_TYPE_MASK) == B91_DEST_ADDR_TYPE_NA) {
-			/* no destination address */
-		} else if ((buf[1] & B91_DEST_ADDR_TYPE_MASK) == B91_DEST_ADDR_TYPE_SHORT) {
-			if (pos + B91_SHORT_ADDRESS_SIZE > size) {
-				break;
-			}
-			if (memcmp(&buf[pos], B91_BROADCAST_ADDRESS, B91_SHORT_ADDRESS_SIZE) != 0 &&
-				memcmp(&buf[pos], data.filter_short_addr,
-					B91_SHORT_ADDRESS_SIZE) != 0) {
-				break;
-			}
-		} else if ((buf[1] & B91_DEST_ADDR_TYPE_MASK) == B91_DEST_ADDR_TYPE_IEEE) {
-			if (pos + B91_IEEE_ADDRESS_SIZE > size) {
-				break;
-			}
-			if ((net_if_get_link_addr(data.iface)->len != B91_IEEE_ADDRESS_SIZE) ||
-				memcmp(&buf[pos], data.filter_ieee_addr,
-					B91_IEEE_ADDRESS_SIZE) != 0) {
-				break;
-			}
-		} else {
-			break;
 		}
 		result = true;
 	} while (0);
@@ -471,176 +327,145 @@ static void b91_set_tx_payload(uint8_t *payload, uint8_t payload_len)
 	memcpy(data.tx_buffer + B91_PAYLOAD_OFFSET, payload, payload_len);
 }
 
-/* Enable ack handler */
-static void b91_handle_ack_en(void)
-{
-	data.ack_handler_en = true;
-}
-
-/* Disable ack handler */
-static void b91_handle_ack_dis(void)
-{
-	data.ack_handler_en = false;
-}
-
 /* Handle acknowledge packet */
-static void b91_handle_ack(void)
+static void b91_handle_ack(const void *buf, size_t buf_len)
 {
-	struct net_pkt *ack_pkt;
+	struct net_pkt *ack_pkt = net_pkt_alloc_with_buffer(
+		data.iface, buf_len, AF_UNSPEC, 0, K_NO_WAIT);
 
-	/* allocate ack packet */
-	ack_pkt = net_pkt_alloc_with_buffer(data.iface, B91_ACK_FRAME_LEN,
-					    AF_UNSPEC, 0, K_NO_WAIT);
-	if (!ack_pkt) {
-		LOG_ERR("No free packet available.");
-		return;
+	do {
+		if (!ack_pkt) {
+			LOG_ERR("No free packet available.");
+			break;
+		}
+		if (net_pkt_write(ack_pkt, buf, buf_len) < 0) {
+			LOG_ERR("Failed to write to a packet.");
+			break;
+		}
+		b91_update_rssi_and_lqi(ack_pkt);
+		net_pkt_cursor_init(ack_pkt);
+		if (ieee802154_radio_handle_ack(data.iface, ack_pkt) != NET_OK) {
+			LOG_INF("ACK packet not handled - releasing.");
+		}
+		k_sem_give(&data.ack_wait);
+	} while (0);
+
+	if (ack_pkt) {
+		net_pkt_unref(ack_pkt);
 	}
-
-	/* update packet data */
-	if (net_pkt_write(ack_pkt, data.rx_buffer + B91_PAYLOAD_OFFSET,
-			  B91_ACK_FRAME_LEN) < 0) {
-		LOG_ERR("Failed to write to a packet.");
-		goto out;
-	}
-
-	/* update RSSI and LQI */
-	b91_update_rssi_and_lqi(ack_pkt);
-
-	/* init net cursor */
-	net_pkt_cursor_init(ack_pkt);
-
-	/* handle ack */
-	if (ieee802154_radio_handle_ack(data.iface, ack_pkt) != NET_OK) {
-		LOG_INF("ACK packet not handled - releasing.");
-	}
-
-	/* release ack_wait semaphore */
-	k_sem_give(&data.ack_wait);
-
-out:
-	net_pkt_unref(ack_pkt);
 }
 
 /* Send acknowledge packet */
-static void b91_send_ack(uint8_t seq_num, bool fp_bit)
+static void b91_send_ack(const struct ieee802154_frame *frame)
 {
-	uint8_t ack_buf[] = { B91_ACK_TYPE, 0, seq_num };
+	uint8_t ack_buf[64];
+	size_t ack_len;
 
-	data.ack_sending = true;
-	k_sem_reset(&data.tx_wait);
-	if (fp_bit) {
-		ack_buf[0] |= B91_FP_BIT;
+	if (b91_ieee802154_frame_build(frame, ack_buf, sizeof(ack_buf), &ack_len)) {
+		data.ack_sending = true;
+		k_sem_reset(&data.tx_wait);
+		b91_set_tx_payload(ack_buf, ack_len);
+		rf_set_txmode();
+		delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
+		rf_tx_pkt(data.tx_buffer);
+	} else {
+		LOG_ERR("Failed to create ACK.");
 	}
-	b91_set_tx_payload(ack_buf, sizeof(ack_buf));
-	rf_set_txmode();
-	delay_us(CONFIG_IEEE802154_B91_SET_TXRX_DELAY_US);
-	rf_tx_pkt(data.tx_buffer);
 }
 
 /* RX IRQ handler */
 static void b91_rf_rx_isr(void)
 {
-	uint8_t status;
-	uint8_t length;
-	uint8_t *payload;
-	struct net_pkt *pkt;
+	int status = -EINVAL;
+	struct net_pkt *pkt = NULL;
 
-	/* disable DMA and clear IRQ flag */
 	dma_chn_dis(DMA1);
 	rf_clr_irq_status(FLD_RF_IRQ_RX);
 
-	/* check CRC */
-	if (rf_zigbee_packet_crc_ok(data.rx_buffer)) {
-		/* get payload length */
-		if (IS_ENABLED(CONFIG_IEEE802154_RAW_MODE) ||
-		    IS_ENABLED(CONFIG_NET_L2_OPENTHREAD)) {
-			length = data.rx_buffer[B91_LENGTH_OFFSET];
-		} else {
-			length = data.rx_buffer[B91_LENGTH_OFFSET] - B91_FCS_LENGTH;
+	do {
+		if (!rf_zigbee_packet_crc_ok(data.rx_buffer)) {
+			break;
 		}
+		uint8_t length = data.rx_buffer[B91_LENGTH_OFFSET];
 
-		/* check length */
 		if ((length < B91_PAYLOAD_MIN) || (length > B91_PAYLOAD_MAX)) {
-			LOG_ERR("Invalid length\n");
-			goto exit;
+			LOG_ERR("Invalid length.\n");
+			break;
 		}
+		uint8_t *payload = (data.rx_buffer + B91_PAYLOAD_OFFSET);
+		struct ieee802154_frame frame;
 
-		/* get payload */
-		payload = (uint8_t *)(data.rx_buffer + B91_PAYLOAD_OFFSET);
-
-		/* handle acknowledge packet if enabled */
-		if ((length == (B91_ACK_FRAME_LEN + B91_FCS_LENGTH)) &&
-		    ((payload[B91_FRAME_TYPE_OFFSET] & B91_FRAME_TYPE_MASK) == B91_ACK_TYPE)) {
+		if (IS_ENABLED(CONFIG_IEEE802154_RAW_MODE) ||
+			IS_ENABLED(CONFIG_NET_L2_OPENTHREAD)) {
+			b91_ieee802154_frame_parse(payload, length - B91_FCS_LENGTH, &frame);
+		} else {
+			length -= B91_FCS_LENGTH;
+			b91_ieee802154_frame_parse(payload, length, &frame);
+		}
+		if (!frame.general.valid) {
+			LOG_ERR("Invalid frame\n");
+			break;
+		}
+		if (frame.general.type == IEEE802154_FRAME_FCF_TYPE_ACK) {
 			if (data.ack_handler_en) {
-				b91_handle_ack();
+				b91_handle_ack(payload, length);
 			}
-			goto exit;
+			break;
 		}
-
-		/* run filter (check PAN ID and destination address) */
-		if (b91_run_filter(payload, length) == false) {
-			LOG_DBG("Packet received is not addressed to me");
-			goto exit;
+		if (!b91_run_filter(&frame)) {
+			LOG_DBG("Packet received is not addressed to me.");
+			break;
 		}
-
-#ifdef CONFIG_OPENTHREAD_FTD
-		bool frame_pending_bit = false;
-#endif /* CONFIG_OPENTHREAD_FTD */
-
-		/* send ack if requested */
-		if (payload[B91_FRAME_TYPE_OFFSET] & B91_ACK_REQUEST) {
-#ifdef CONFIG_OPENTHREAD_FTD
-
-			uint8_t m_sn;
-			const uint8_t *m_addr;
-			bool m_ext;
-
-			if (b91_is_data_request(payload, length, &m_sn, &m_addr, &m_ext)) {
-				if (m_addr) {
-					if (!data.src_match_table->enabled ||
-						b91_src_match_table_search(data.src_match_table,
-							m_addr, m_ext)) {
-						frame_pending_bit = true;
-					}
-				}
-				b91_send_ack(m_sn, frame_pending_bit);
-			} else {
-				b91_send_ack(payload[B91_DSN_OFFSET], false);
-			}
-#else
-			b91_send_ack(payload[B91_DSN_OFFSET], false);
-#endif /* CONFIG_OPENTHREAD_FTD */
-		}
-
-		/* get packet pointer from NET stack */
 		pkt = net_pkt_alloc_with_buffer(data.iface, length, AF_UNSPEC, 0, K_NO_WAIT);
 		if (!pkt) {
-			LOG_ERR("No pkt available");
-			goto exit;
+			LOG_ERR("No pkt available.");
+			break;
 		}
-
-		/* update packet data */
+		if (frame.general.ack_req) {
+#ifdef CONFIG_OPENTHREAD_FTD
+			if (b91_require_pending_bit(&frame)) {
+				if (frame.src_addr) {
+					if (!data.src_match_table->enabled ||
+						b91_src_match_table_search(data.src_match_table,
+							frame.src_addr, frame.src_addr_ext)) {
+						net_pkt_set_ieee802154_ack_fpb(pkt, true);
+					} else {
+						net_pkt_set_ieee802154_ack_fpb(pkt, false);
+					}
+				} else {
+					net_pkt_set_ieee802154_ack_fpb(pkt, false);
+				}
+			} else {
+				net_pkt_set_ieee802154_ack_fpb(pkt, false);
+			}
+#else
+			net_pkt_set_ieee802154_ack_fpb(pkt, false);
+#endif
+			const struct ieee802154_frame ack_frame = {
+				.general = {
+					.valid = true,
+					.ver = IEEE802154_FRAME_FCF_VER_2003,
+					.type = IEEE802154_FRAME_FCF_TYPE_ACK,
+					.fp_bit = net_pkt_ieee802154_ack_fpb(pkt)
+				},
+				.sn = frame.sn
+			};
+			b91_send_ack(&ack_frame);
+		}
 		if (net_pkt_write(pkt, payload, length)) {
 			LOG_ERR("Failed to write to a packet.");
-			net_pkt_unref(pkt);
-			goto exit;
+			break;
 		}
-#ifdef CONFIG_OPENTHREAD_FTD
-		/* frame pending bit */
-		net_pkt_set_ieee802154_ack_fpb(pkt, frame_pending_bit);
-#endif /* CONFIG_OPENTHREAD_FTD */
-		/* update RSSI and LQI parameters */
 		b91_update_rssi_and_lqi(pkt);
-
-		/* transfer data to NET stack */
 		status = net_recv_data(data.iface, pkt);
 		if (status < 0) {
 			LOG_ERR("RCV Packet dropped by NET stack: %d", status);
-			net_pkt_unref(pkt);
 		}
-	}
+	} while (0);
 
-exit:
+	if (status < 0 && pkt != NULL) {
+		net_pkt_unref(pkt);
+	}
 	dma_chn_en(DMA1);
 }
 
@@ -716,7 +541,7 @@ static void b91_iface_init(struct net_if *iface)
 	struct b91_data *b91 = dev->data;
 	uint8_t *mac = b91_get_mac(dev);
 
-	net_if_set_link_addr(iface, mac, B91_IEEE_ADDRESS_SIZE, NET_LINK_IEEE802154);
+	net_if_set_link_addr(iface, mac, IEEE802154_FRAME_LENGTH_ADDR_EXT, NET_LINK_IEEE802154);
 
 	b91->iface = iface;
 
@@ -858,7 +683,7 @@ static int b91_tx(const struct device *dev,
 
 	/* check for supported mode */
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
-		LOG_DBG("TX mode %d not supported", mode);
+		LOG_WRN("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 
@@ -888,12 +713,13 @@ static int b91_tx(const struct device *dev,
 	}
 
 	/* wait for ACK if requested */
-	if (!status && frag->data[B91_FRAME_TYPE_OFFSET] & B91_ACK_REQUEST) {
-		b91_handle_ack_en();
+	if (!status && (frag->data[0] & IEEE802154_FRAME_FCF_ACK_REQ_MASK) ==
+		IEEE802154_FRAME_FCF_ACK_REQ_ON) {
+		data.ack_handler_en = true;
 		if (k_sem_take(&b91->ack_wait, K_MSEC(B91_ACK_WAIT_TIME_MS)) != 0) {
 			status = -ENOMSG;
 		}
-		b91_handle_ack_dis();
+		data.ack_handler_en = false;
 	}
 
 	return status;
@@ -961,6 +787,14 @@ static int b91_configure(const struct device *dev,
 	return result;
 }
 
+/* API implementation: get_sch_acc */
+static uint8_t b91_get_sch_acc(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return CONFIG_IEEE802154_B91_DELAY_TRX_ACC;
+}
+
 /* IEEE802154 driver APIs structure */
 static struct ieee802154_radio_api b91_radio_api = {
 	.iface_api.init = b91_iface_init,
@@ -974,6 +808,7 @@ static struct ieee802154_radio_api b91_radio_api = {
 	.tx = b91_tx,
 	.ed_scan = b91_ed_scan,
 	.configure = b91_configure,
+	.get_sch_acc = b91_get_sch_acc,
 };
 
 

--- a/drivers/ieee802154/ieee802154_b91.h
+++ b/drivers/ieee802154/ieee802154_b91.h
@@ -12,65 +12,23 @@
 #define B91_ACK_WAIT_TIME_MS                (10)
 
 /* Received data parsing */
+#ifndef IEEE802154_FRAME_LENGTH_PANID
+#define IEEE802154_FRAME_LENGTH_PANID       (2)
+#endif
+#ifndef IEEE802154_FRAME_LENGTH_ADDR_SHORT
+#define IEEE802154_FRAME_LENGTH_ADDR_SHORT  (2)
+#endif
+#ifndef IEEE802154_FRAME_LENGTH_ADDR_EXT
+#define IEEE802154_FRAME_LENGTH_ADDR_EXT    (8)
+#endif
 #define B91_PAYLOAD_OFFSET                  (5)
 #define B91_PAYLOAD_MIN                     (5)
 #define B91_PAYLOAD_MAX                     (127)
-#define B91_FRAME_TYPE_OFFSET               (0)
-#define B91_FRAME_TYPE_MASK                 (0x07)
-#define B91_DEST_ADDR_TYPE_OFFSET           (1)
-#define B91_DEST_ADDR_TYPE_MASK             (0x0c)
-#define B91_DEST_ADDR_TYPE_SHORT            (8)
-#define B91_DEST_ADDR_TYPE_IEEE             (0x0c)
-#define B91_PAN_ID_OFFSET                   (3)
-#define B91_PAN_ID_SIZE                     (2)
-#define B91_DEST_ADDR_OFFSET                (5)
-#define B91_SHORT_ADDRESS_SIZE              (2)
-#define B91_IEEE_ADDRESS_SIZE               (8)
 #define B91_LENGTH_OFFSET                   (4)
 #define B91_RSSI_OFFSET                     (11)
 #define B91_BROADCAST_ADDRESS               ((uint8_t [2]) { 0xff, 0xff })
-#define B91_ACK_FRAME_LEN                   (3)
-#define B91_ACK_TYPE                        (2)
-#define B91_ACK_REQUEST                     (1 << 5)
-#define B91_DSN_OFFSET                      (2)
 #define B91_FCS_LENGTH                      (2)
-#define B91_FRAME_TYPE_CMD                  (3)
-#define B91_DEST_ADDR_TYPE_NA               (0x00)
-#define B91_SRC_ADDR_TYPE_MASK              (0xc0)
-#define B91_SRC_ADDR_TYPE_SHORT             (0x80)
-#define B91_SRC_ADDR_TYPE_IEEE              (0xc0)
-#define B91_SRC_ADDR_TYPE_NA                (0x00)
-#define B91_PANID_COMPRESSION_MASK          (0x40)
-#define B91_PANID_COMPRESSION_ON            (0x40)
-#define B91_PANID_COMPRESSION_OFF           (0x00)
-#define B91_SECURITY_EABLE_MASK             (0x08)
-#define B91_SECURITY_EABLE_ON               (0x08)
-#define B91_SECURITY_EABLE_OFF              (0x00)
-#define B91_KEY_ID_MODE_MASK                (0x18)
-#define B91_KEY_ID_MODE_0                   (0x00)
-#define B91_KEY_ID_MODE_1                   (0x08)
-#define B91_KEY_ID_MODE_2                   (0x10)
-#define B91_KEY_ID_MODE_3                   (0x18)
-#define B91_CMD_ID_DATA_REQ                 (4)
-#define B91_FP_BIT                          (1 << 4)
-#define B91_KEY_ID_MODE_0_LEN               (5)
-#define B91_KEY_ID_MODE_1_LEN               (6)
-#define B91_KEY_ID_MODE_2_LEN               (10)
-#define B91_KEY_ID_MODE_3_LEN               (14)
-#define B91_FRAME_VER_MASK                  (0x30)
-#define B91_FRAME_VER_2003                  (0x00)
-#define B91_FRAME_VER_2006                  (0x10)
-#define B91_FRAME_VER_2015                  (0x20)
-#define B91_IE_PRESENT_MASK                 (0x02)
-#define B91_IE_PRESENT_ON                   (0x02)
-#define B91_IE_PRESENT_OFF                  (0x00)
-#define B91_IE_LEN_MASK						(0x7f)
-#define B91_IE_TYPE_H_MASK					(0x7f)
-#define B91_IE_TYPE_L_MASK					(0x80)
-#define B91_IE_TYPE_H_OFS					(1)
-#define B91_IE_TYPE_L_OFS					(7)
-#define B91_IE_TYPE_TERMINATE				(0x7f)
-#define B91_IE_HEADER_SIZE					(2)
+#define B91_CMD_ID_DATA_REQ                 (0x04)
 
 /* Generic */
 #define B91_TRX_LENGTH                      (256)
@@ -132,22 +90,23 @@ struct b91_src_match_table {
 	struct {
 		bool valid;
 		bool ext;
-		uint8_t addr[MAX(B91_IEEE_ADDRESS_SIZE, B91_SHORT_ADDRESS_SIZE)];
+		uint8_t addr[MAX(IEEE802154_FRAME_LENGTH_ADDR_EXT,
+			IEEE802154_FRAME_LENGTH_ADDR_SHORT)];
 	} item[CONFIG_OPENTHREAD_MAX_CHILDREN];
 };
 #endif /* CONFIG_OPENTHREAD_FTD */
 
 /* data structure */
 struct b91_data {
-	uint8_t mac_addr[B91_IEEE_ADDRESS_SIZE];
+	uint8_t mac_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
 	uint8_t rx_buffer[B91_TRX_LENGTH] __aligned(4);
 	uint8_t tx_buffer[B91_TRX_LENGTH] __aligned(4);
 	struct net_if *iface;
 	struct k_sem tx_wait;
 	struct k_sem ack_wait;
-	uint8_t filter_pan_id[B91_PAN_ID_SIZE];
-	uint8_t filter_short_addr[B91_SHORT_ADDRESS_SIZE];
-	uint8_t filter_ieee_addr[B91_IEEE_ADDRESS_SIZE];
+	uint8_t filter_pan_id[IEEE802154_FRAME_LENGTH_PANID];
+	uint8_t filter_short_addr[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
+	uint8_t filter_ieee_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
 	bool is_started;
 	volatile bool ack_handler_en;
 	uint16_t current_channel;

--- a/drivers/ieee802154/ieee802154_b91_frame.c
+++ b/drivers/ieee802154/ieee802154_b91_frame.c
@@ -1,0 +1,583 @@
+/*
+ * Copyright (c) 2021 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+
+/* frame control field byte 0 */
+#define IEEE802154_FRAME_FCF_TYPE_MASK             (0x07)
+#define IEEE802154_FRAME_FCF_TYPE_BEACON           (0x00)
+#define IEEE802154_FRAME_FCF_TYPE_DATA             (0x01)
+#define IEEE802154_FRAME_FCF_TYPE_ACK              (0x02)
+#define IEEE802154_FRAME_FCF_TYPE_CMD              (0x03)
+#define IEEE802154_FRAME_FCF_SECURITY_EN_MASK      (0x08)
+#define IEEE802154_FRAME_FCF_SECURITY_EN_ON        (0x08)
+#define IEEE802154_FRAME_FCF_SECURITY_EN_OFF       (0x00)
+#define IEEE802154_FRAME_FCF_PENDING_MASK          (0x10)
+#define IEEE802154_FRAME_FCF_PENDING_ON            (0x10)
+#define IEEE802154_FRAME_FCF_PENDING_OFF           (0x10)
+#define IEEE802154_FRAME_FCF_ACK_REQ_MASK          (0x20)
+#define IEEE802154_FRAME_FCF_ACK_REQ_ON            (0x20)
+#define IEEE802154_FRAME_FCF_ACK_REQ_OFF           (0x20)
+#define IEEE802154_FRAME_FCF_PANID_COMP_MASK       (0x40)
+#define IEEE802154_FRAME_FCF_PANID_COMP_ON         (0x40)
+#define IEEE802154_FRAME_FCF_PANID_COMP_OFF        (0x00)
+
+/* frame control field byte 1 */
+#define IEEE802154_FRAME_FCF_SN_SUP_MASK           (0x01)
+#define IEEE802154_FRAME_FCF_SN_SUP_ON             (0x01)
+#define IEEE802154_FRAME_FCF_SN_SUP_OFF            (0x00)
+#define IEEE802154_FRAME_FCF_IE_MASK               (0x02)
+#define IEEE802154_FRAME_FCF_IE_ON                 (0x02)
+#define IEEE802154_FRAME_FCF_IE_OFF                (0x00)
+#define IEEE802154_FRAME_FCF_DST_ADDR_T_MASK       (0x0c)
+#define IEEE802154_FRAME_FCF_DST_ADDR_T_NA         (0x00)
+#define IEEE802154_FRAME_FCF_DST_ADDR_T_SHORT      (0x08)
+#define IEEE802154_FRAME_FCF_DST_ADDR_T_EXT        (0x0c)
+#define IEEE802154_FRAME_FCF_VER_MASK              (0x30)
+#define IEEE802154_FRAME_FCF_VER_OFS               (4)
+#define IEEE802154_FRAME_FCF_VER_2003              (0x00)
+#define IEEE802154_FRAME_FCF_VER_2006              (0x01)
+#define IEEE802154_FRAME_FCF_VER_2015              (0x02)
+#define IEEE802154_FRAME_FCF_SRC_ADDR_T_MASK       (0xc0)
+#define IEEE802154_FRAME_FCF_SRC_ADDR_T_NA         (0x00)
+#define IEEE802154_FRAME_FCF_SRC_ADDR_T_SHORT      (0x80)
+#define IEEE802154_FRAME_FCF_SRC_ADDR_T_EXT        (0xc0)
+
+/* security control byte */
+#define IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_MASK  (0x18)
+#define IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_0     (0x00)
+#define IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_1     (0x08)
+#define IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_2     (0x10)
+#define IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_3     (0x18)
+
+/* IE header byte 0 */
+#define IEEE802154_FRAME_IE_HEADER_LEN_MASK        (0x7f)
+#define IEEE802154_FRAME_IE_HEADER_TYPE_L_MASK     (0x80)
+#define IEEE802154_FRAME_IE_HEADER_TYPE_L_OFS      (7)
+
+/* IE header byte 1 */
+#define IEEE802154_FRAME_IE_HEADER_TYPE_H_MASK     (0x7f)
+#define IEEE802154_FRAME_IE_HEADER_TYPE_H_OFS      (1)
+
+/* IE header types */
+#define IEEE802154_FRAME_IE_HEADER_TYPE_TERM       (0x7f)
+
+/* elements lengths */
+#define IEEE802154_FRAME_LENGTH_FCF                (2)
+#define IEEE802154_FRAME_LENGTH_SN                 (1)
+#ifndef IEEE802154_FRAME_LENGTH_PANID
+#define IEEE802154_FRAME_LENGTH_PANID              (2)
+#endif
+#ifndef IEEE802154_FRAME_LENGTH_ADDR_SHORT
+#define IEEE802154_FRAME_LENGTH_ADDR_SHORT         (2)
+#endif
+#ifndef IEEE802154_FRAME_LENGTH_ADDR_EXT
+#define IEEE802154_FRAME_LENGTH_ADDR_EXT           (8)
+#endif
+#define IEEE802154_FRAME_LENGTH_SEC_HEADER         (1)
+#define IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_0  (4)
+#define IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_1  (5)
+#define IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_2  (9)
+#define IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_3  (13)
+#define IEEE802154_FRAME_LENGTH_IE_HEADER          (2)
+
+
+/* ieee802154_frame structure */
+struct ieee802154_frame {
+	struct {
+		bool valid;
+		uint8_t ver;
+		uint8_t type;
+		bool ack_req;
+		bool fp_bit;
+	} general;
+	const uint8_t *sn;
+	const uint8_t *dst_panid;
+	const uint8_t *dst_addr;
+	bool dst_addr_ext;
+	const uint8_t *src_panid;
+	const uint8_t *src_addr;
+	bool src_addr_ext;
+	const uint8_t *sec_header;
+	size_t sec_header_len;
+	const uint8_t *ie_header;
+	size_t ie_header_len;
+	const uint8_t *data;
+	size_t data_len;
+};
+
+
+/*
+ * Check if FCF describes destination PANID
+ * fcf should be valid and contains at lest 2 bytes
+ */
+static bool ieee802154_frame_has_dest_panid(const uint8_t fcf[2])
+{
+	bool result = true;
+	const uint8_t frame_ver_t = (fcf[1] & IEEE802154_FRAME_FCF_VER_MASK) >>
+		IEEE802154_FRAME_FCF_VER_OFS;
+	const uint8_t dst_addr_t = fcf[1] & IEEE802154_FRAME_FCF_DST_ADDR_T_MASK;
+	const uint8_t src_addr_t = fcf[1] & IEEE802154_FRAME_FCF_SRC_ADDR_T_MASK;
+	const uint8_t panid_compr_t = fcf[0] & IEEE802154_FRAME_FCF_PANID_COMP_MASK;
+
+	if (frame_ver_t == IEEE802154_FRAME_FCF_VER_2015) {
+		if ((dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_NA &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_NA &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_OFF) ||
+			(dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_EXT &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_NA &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_ON) ||
+			(dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_SHORT &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_NA &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_ON) ||
+			(dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_NA &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_EXT &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_OFF) ||
+			(dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_NA &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_SHORT &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_OFF) ||
+			(dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_NA &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_EXT &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_ON) ||
+			(dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_NA &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_SHORT &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_ON) ||
+			(dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_EXT &&
+				src_addr_t == IEEE802154_FRAME_FCF_SRC_ADDR_T_EXT &&
+				panid_compr_t == IEEE802154_FRAME_FCF_PANID_COMP_ON)) {
+			result = false;
+		}
+	} else {
+		if (dst_addr_t == IEEE802154_FRAME_FCF_DST_ADDR_T_NA) {
+			result = false;
+		}
+	}
+
+	return result;
+}
+
+/*
+ * return PANID compression bit
+ * frame should be valid
+ */
+static bool ieee802154_frame_panid_compression(const struct ieee802154_frame *frame)
+{
+	bool result = false;
+
+	if (frame->general.ver == IEEE802154_FRAME_FCF_VER_2015) {
+		if ((frame->dst_addr == NULL && frame->src_addr == NULL &&
+				frame->dst_panid != NULL && frame->src_panid == NULL) ||
+			(frame->dst_addr != NULL && frame->src_addr == NULL &&
+				frame->dst_panid == NULL && frame->src_panid == NULL) ||
+			(frame->dst_addr == NULL && frame->src_addr != NULL &&
+				frame->dst_panid == NULL && frame->src_panid == NULL) ||
+			(frame->dst_addr != NULL && frame->dst_addr_ext &&
+				frame->src_addr != NULL && frame->src_addr_ext &&
+				frame->dst_panid == NULL && frame->src_panid == NULL) ||
+			(frame->dst_addr != NULL && !frame->dst_addr_ext &&
+				frame->src_addr != NULL && frame->src_addr_ext &&
+				frame->dst_panid != NULL && frame->src_panid == NULL) ||
+			(frame->dst_addr != NULL && frame->dst_addr_ext &&
+				frame->src_addr != NULL && !frame->src_addr_ext &&
+				frame->dst_panid != NULL && frame->src_panid == NULL) ||
+			(frame->dst_addr != NULL && !frame->dst_addr_ext &&
+				frame->src_addr != NULL && !frame->src_addr_ext &&
+				frame->dst_panid != NULL && frame->src_panid == NULL)) {
+			result = true;
+		}
+	} else {
+		if ((frame->src_panid == NULL && frame->src_addr != NULL) ||
+			(frame->dst_panid != NULL &&
+				frame->dst_addr != NULL && frame->dst_addr_ext &&
+				frame->src_addr != NULL && frame->src_addr_ext)) {
+			result = true;
+		}
+	}
+
+	return result;
+}
+
+/*
+ * Parse IEEE802154 buffer
+ * buf & frame should be valid
+ */
+static void b91_ieee802154_frame_parse(const uint8_t *buf, size_t bul_len,
+	struct ieee802154_frame *frame)
+{
+	size_t pos = 0; /* current buffer position */
+
+	if (bul_len >= pos + IEEE802154_FRAME_LENGTH_FCF) {
+		frame->general.ver = (buf[1] & IEEE802154_FRAME_FCF_VER_MASK) >>
+			IEEE802154_FRAME_FCF_VER_OFS;
+		frame->general.type = buf[0] & IEEE802154_FRAME_FCF_TYPE_MASK;
+		if ((buf[0] & IEEE802154_FRAME_FCF_ACK_REQ_MASK) ==
+			IEEE802154_FRAME_FCF_ACK_REQ_ON) {
+			frame->general.ack_req = true;
+		} else {
+			frame->general.ack_req = false;
+		}
+		if ((buf[0] & IEEE802154_FRAME_FCF_PENDING_MASK) ==
+			IEEE802154_FRAME_FCF_PENDING_ON) {
+			frame->general.fp_bit = true;
+		} else {
+			frame->general.fp_bit = false;
+		}
+		frame->general.valid = true;
+	} else {
+		frame->general.valid = false;
+		frame->general.ver = IEEE802154_FRAME_FCF_VER_2003;
+		frame->general.type = IEEE802154_FRAME_FCF_TYPE_BEACON;
+		frame->general.ack_req = false;
+		frame->general.fp_bit = false;
+	}
+	pos += IEEE802154_FRAME_LENGTH_FCF;	/* FCF[2] */
+	/* at sequence number */
+	if (bul_len >= pos + IEEE802154_FRAME_LENGTH_SN) {
+		frame->sn = &buf[IEEE802154_FRAME_LENGTH_FCF];
+	} else {
+		frame->sn = NULL;
+	}
+	pos += IEEE802154_FRAME_LENGTH_SN;  /* SN[1] */
+	/* at destination PANID */
+	if (frame->general.valid && ieee802154_frame_has_dest_panid(buf)) {
+		if (bul_len >= pos + IEEE802154_FRAME_LENGTH_PANID) {
+			frame->dst_panid = &buf[pos];
+		} else {
+			frame->dst_panid = NULL;
+		}
+		pos += IEEE802154_FRAME_LENGTH_PANID; /* PANID[2] */
+	} else {
+		frame->dst_panid = NULL;
+	}
+	/* at destination address */
+	if (frame->general.valid) {
+		switch (buf[1] & IEEE802154_FRAME_FCF_DST_ADDR_T_MASK) {
+		case IEEE802154_FRAME_FCF_DST_ADDR_T_NA:
+			frame->dst_addr = NULL;
+			frame->dst_addr_ext = false;
+			break;
+		case IEEE802154_FRAME_FCF_DST_ADDR_T_SHORT:
+			if (bul_len >= pos + IEEE802154_FRAME_LENGTH_ADDR_SHORT) {
+				frame->dst_addr = &buf[pos];
+			} else {
+				frame->dst_addr = NULL;
+			}
+			frame->dst_addr_ext = false;
+			pos += IEEE802154_FRAME_LENGTH_ADDR_SHORT; /* ADDR[2] */
+			break;
+		case IEEE802154_FRAME_FCF_DST_ADDR_T_EXT:
+			if (bul_len >= pos + IEEE802154_FRAME_LENGTH_ADDR_EXT) {
+				frame->dst_addr = &buf[pos];
+			} else {
+				frame->dst_addr = NULL;
+			}
+			frame->dst_addr_ext = true;
+			pos += IEEE802154_FRAME_LENGTH_ADDR_EXT; /* ADDR[8] */
+			break;
+		default:
+			frame->dst_addr = NULL;
+			frame->dst_addr_ext = false;
+			break;
+		}
+	} else {
+		frame->dst_addr = NULL;
+		frame->dst_addr_ext = false;
+	}
+	/* at source PAN ID */
+	if (frame->general.valid &&
+		(buf[1] & IEEE802154_FRAME_FCF_SRC_ADDR_T_MASK) !=
+			IEEE802154_FRAME_FCF_SRC_ADDR_T_NA &&
+		(buf[0] & IEEE802154_FRAME_FCF_PANID_COMP_MASK) ==
+			IEEE802154_FRAME_FCF_PANID_COMP_OFF) {
+		if (frame->general.ver  != IEEE802154_FRAME_FCF_VER_2015 ||
+			(buf[1] & IEEE802154_FRAME_FCF_DST_ADDR_T_MASK) !=
+				IEEE802154_FRAME_FCF_DST_ADDR_T_EXT ||
+			(buf[1] & IEEE802154_FRAME_FCF_SRC_ADDR_T_MASK) !=
+				IEEE802154_FRAME_FCF_SRC_ADDR_T_EXT) {
+			if (bul_len >= pos + IEEE802154_FRAME_LENGTH_PANID) {
+				frame->src_panid = &buf[pos];
+			} else {
+				frame->src_panid = NULL;
+			}
+			pos += IEEE802154_FRAME_LENGTH_PANID; /* PANID[2] */
+		} else {
+			frame->src_panid = NULL;
+		}
+	} else {
+		frame->src_panid = NULL;
+	}
+	/* at source address */
+	if (frame->general.valid) {
+		switch (buf[1] & IEEE802154_FRAME_FCF_SRC_ADDR_T_MASK) {
+		case IEEE802154_FRAME_FCF_SRC_ADDR_T_NA:
+			frame->src_addr = NULL;
+			frame->src_addr_ext = false;
+			break;
+		case IEEE802154_FRAME_FCF_SRC_ADDR_T_SHORT:
+			if (bul_len >= pos + IEEE802154_FRAME_LENGTH_ADDR_SHORT) {
+				frame->src_addr = &buf[pos];
+			} else {
+				frame->src_addr = NULL;
+			}
+			frame->src_addr_ext = false;
+			pos += IEEE802154_FRAME_LENGTH_ADDR_SHORT; /* ADDR[2] */
+			break;
+		case IEEE802154_FRAME_FCF_SRC_ADDR_T_EXT:
+			if (bul_len >= pos + IEEE802154_FRAME_LENGTH_ADDR_EXT) {
+				frame->src_addr = &buf[pos];
+			} else {
+				frame->src_addr = NULL;
+			}
+			frame->src_addr_ext = true;
+			pos += IEEE802154_FRAME_LENGTH_ADDR_EXT; /* ADDR[8] */
+			break;
+		default:
+			frame->src_addr = NULL;
+			frame->src_addr_ext = false;
+			break;
+		}
+	} else {
+		frame->src_addr = NULL;
+		frame->src_addr_ext = false;
+	}
+	/* at security header */
+	if (frame->general.valid &&
+		(buf[0] & IEEE802154_FRAME_FCF_SECURITY_EN_MASK) ==
+			IEEE802154_FRAME_FCF_SECURITY_EN_ON) {
+		if (bul_len >= pos + IEEE802154_FRAME_LENGTH_SEC_HEADER) {
+			switch (buf[pos] & IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_MASK) {
+			case IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_0:
+				if (bul_len >= pos + IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_0) {
+					frame->sec_header = &buf[pos];
+					frame->sec_header_len = IEEE802154_FRAME_LENGTH_SEC_HEADER
+						+ IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_0;
+				} else {
+					frame->sec_header = NULL;
+				}
+				/* FC[4] */
+				pos += IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_0;
+				break;
+			case IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_1:
+				if (bul_len >= pos + IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_1) {
+					frame->sec_header = &buf[pos];
+					frame->sec_header_len = IEEE802154_FRAME_LENGTH_SEC_HEADER
+						+ IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_1;
+				} else {
+					frame->sec_header = NULL;
+				}
+				/* FC[4], KEYID[1] */
+				pos += IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_1;
+				break;
+			case IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_2:
+				if (bul_len >= pos + IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_2) {
+					frame->sec_header = &buf[pos];
+					frame->sec_header_len = IEEE802154_FRAME_LENGTH_SEC_HEADER
+						+ IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_2;
+				} else {
+					frame->sec_header = NULL;
+				}
+				/* FC[4], KEY[4], KEYID[1] */
+				pos += IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_2;
+				break;
+			case IEEE802154_FRAME_SECCTRL_KEY_ID_MODE_3:
+				if (bul_len >= pos + IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_3) {
+					frame->sec_header = &buf[pos];
+					frame->sec_header_len = IEEE802154_FRAME_LENGTH_SEC_HEADER
+						+ IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_3;
+				} else {
+					frame->sec_header = NULL;
+				}
+				/* FC[4], KEY[8], KEYID[1] */
+				pos += IEEE802154_FRAME_LENGTH_SEC_HEADER_MODE_3;
+				break;
+			default:
+				frame->sec_header = NULL;
+				break;
+			}
+		} else {
+			frame->sec_header = NULL;
+		}
+		pos += IEEE802154_FRAME_LENGTH_SEC_HEADER;
+	} else {
+		frame->sec_header = NULL;
+	}
+	/* at IE header */
+	bool ie_error = false;
+
+	if (frame->general.valid &&
+		(buf[1] & IEEE802154_FRAME_FCF_IE_MASK) == IEEE802154_FRAME_FCF_IE_ON) {
+		frame->ie_header = NULL;
+		frame->ie_header_len = 0;
+		ie_error = true;
+		while (bul_len >= pos + frame->ie_header_len) {
+			if (frame->ie_header == NULL) {
+				frame->ie_header = &buf[pos];
+			}
+			uint8_t ie_type =
+				((buf[pos + frame->ie_header_len + 1] &
+					IEEE802154_FRAME_IE_HEADER_TYPE_H_MASK)
+					<< IEEE802154_FRAME_IE_HEADER_TYPE_H_OFS) |
+				((buf[pos + frame->ie_header_len] &
+					IEEE802154_FRAME_IE_HEADER_TYPE_L_MASK)
+					>> IEEE802154_FRAME_IE_HEADER_TYPE_L_OFS);
+
+			frame->ie_header_len += IEEE802154_FRAME_LENGTH_IE_HEADER +
+				(buf[pos + frame->ie_header_len] &
+				IEEE802154_FRAME_IE_HEADER_LEN_MASK);
+			if (ie_type == IEEE802154_FRAME_IE_HEADER_TYPE_TERM) {
+				ie_error = false;
+				break;
+			}
+		}
+	} else {
+		frame->ie_header = NULL;
+	}
+	if (ie_error) {
+		frame->ie_header_len = bul_len - pos;
+		pos = bul_len;
+	} else if (frame->ie_header) {
+		pos += frame->ie_header_len;
+	}
+	/* at payload */
+	if (pos < bul_len) {
+		frame->data = &buf[pos];
+		frame->data_len = bul_len - pos;
+	} else {
+		frame->data = NULL;
+		frame->data_len = 0;
+	}
+}
+
+/*
+ * Create ACK buffer
+ * frame & buf should be valid
+ */
+static bool b91_ieee802154_frame_build(const struct ieee802154_frame *frame,
+	uint8_t *buf, size_t bul_len, size_t *o_len)
+{
+	bool result = false;
+
+	do {
+		if (!frame->general.valid) {
+			break;
+		}
+		*o_len = 0;
+		/* at frame control */
+		if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_FCF) {
+			break;
+		}
+		buf[1] = (frame->general.ver << IEEE802154_FRAME_FCF_VER_OFS) &
+			IEEE802154_FRAME_FCF_VER_MASK;
+		buf[0] = frame->general.type & IEEE802154_FRAME_FCF_TYPE_MASK;
+		if (frame->general.fp_bit) {
+			buf[0] |= IEEE802154_FRAME_FCF_PENDING_ON;
+		}
+		if (frame->general.ack_req) {
+			buf[0] |= IEEE802154_FRAME_FCF_ACK_REQ_ON;
+		}
+		if (ieee802154_frame_panid_compression(frame)) {
+			buf[0] |= IEEE802154_FRAME_FCF_PANID_COMP_ON;
+		}
+		*o_len += IEEE802154_FRAME_LENGTH_FCF;	/* FCF[2] */
+
+		if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_SN) {
+			break;
+		}
+		buf[*o_len] = *frame->sn;
+		*o_len += IEEE802154_FRAME_LENGTH_SN; /* SN[1] */
+
+		if (frame->dst_panid != NULL) {
+			if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_PANID) {
+				break;
+			}
+			memcpy(&buf[*o_len], frame->dst_panid, IEEE802154_FRAME_LENGTH_PANID);
+			*o_len += IEEE802154_FRAME_LENGTH_PANID; /* PANID[2] */
+		}
+
+		if (frame->dst_addr != NULL) {
+			if (frame->dst_addr_ext) {
+
+				if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_ADDR_EXT) {
+					break;
+				}
+				buf[1] |= IEEE802154_FRAME_FCF_DST_ADDR_T_EXT;
+				memcpy(&buf[*o_len], frame->dst_addr,
+					IEEE802154_FRAME_LENGTH_ADDR_EXT);
+				*o_len += IEEE802154_FRAME_LENGTH_ADDR_EXT; /* ADDR[8] */
+			} else {
+				if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_ADDR_SHORT) {
+					break;
+				}
+				buf[1] |= IEEE802154_FRAME_FCF_DST_ADDR_T_SHORT;
+				memcpy(&buf[*o_len], frame->dst_addr,
+					IEEE802154_FRAME_LENGTH_ADDR_SHORT);
+				*o_len += IEEE802154_FRAME_LENGTH_ADDR_SHORT; /* ADDR[2] */
+			}
+		}
+
+		if (frame->src_panid != NULL) {
+			if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_PANID) {
+				break;
+			}
+			memcpy(&buf[*o_len], frame->src_panid, IEEE802154_FRAME_LENGTH_PANID);
+			*o_len += IEEE802154_FRAME_LENGTH_PANID; /* PANID[2] */
+		}
+
+		if (frame->src_addr != NULL) {
+			if (frame->src_addr_ext) {
+				if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_ADDR_EXT) {
+					break;
+				}
+				buf[1] |= IEEE802154_FRAME_FCF_SRC_ADDR_T_EXT;
+				memcpy(&buf[*o_len], frame->src_addr,
+					IEEE802154_FRAME_LENGTH_ADDR_EXT);
+				*o_len += IEEE802154_FRAME_LENGTH_ADDR_EXT; /* ADDR[8] */
+			} else {
+				if (bul_len < *o_len + IEEE802154_FRAME_LENGTH_ADDR_SHORT) {
+					break;
+				}
+				buf[1] |= IEEE802154_FRAME_FCF_SRC_ADDR_T_SHORT;
+				memcpy(&buf[*o_len], frame->src_addr,
+					IEEE802154_FRAME_LENGTH_ADDR_SHORT);
+				*o_len += IEEE802154_FRAME_LENGTH_ADDR_SHORT; /* ADDR[2] */
+			}
+		}
+
+		if (frame->sec_header != NULL) {
+
+			if (bul_len < *o_len + frame->sec_header_len) {
+				break;
+			}
+			buf[0] |= IEEE802154_FRAME_FCF_SECURITY_EN_ON;
+			memcpy(&buf[*o_len], frame->sec_header, frame->sec_header_len);
+			*o_len += frame->sec_header_len;
+		}
+
+		if (frame->ie_header != NULL) {
+
+			if (bul_len < *o_len + frame->ie_header_len) {
+				break;
+			}
+			buf[1] |= IEEE802154_FRAME_FCF_IE_ON;
+			memcpy(&buf[*o_len], frame->ie_header, frame->ie_header_len);
+			*o_len += frame->ie_header_len;
+		}
+		if (frame->data != NULL) {
+			if (bul_len < *o_len + frame->data_len) {
+				break;
+			}
+			memcpy(&buf[*o_len], frame->data, frame->data_len);
+			*o_len += frame->data_len;
+		}
+		result = true;
+	} while (0);
+
+	return result;
+}


### PR DESCRIPTION
Openthread protocol version 1.2 or newer should parse IEEE802.15.4 frames version 2015. In driver parsing is used during RX filtration and TX ACK procedure.

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>