### PR TITLE
drivers: ieee802154: telink: Enhanced ACK link metrics

### DIFF
--- a/drivers/ieee802154/Kconfig.b91
+++ b/drivers/ieee802154/Kconfig.b91
@@ -36,6 +36,13 @@ config IEEE802154_B91_RANDOM_MAC
 	help
 	  Generate a random MAC address dynamically.
 
+config IEEE802154_B91_DELAY_TRX_ACC
+	int "Clock accuracy for delayed operations"
+	default 20
+	help
+	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
+	  or delayed reception), in ppm.
+
 if ! IEEE802154_B91_RANDOM_MAC
 
 config IEEE802154_B91_MAC4
@@ -65,13 +72,6 @@ config IEEE802154_B91_MAC7
 	range 0 0xff
 	help
 	  This is the byte 7 of the MAC address.
-
-config IEEE802154_B91_DELAY_TRX_ACC
-	int "Clock accuracy for delayed operations"
-	default 20
-	help
-	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
-	  or delayed reception), in ppm.
 
 endif # ! IEEE802154_B91_RANDOM_MAC
 endif # IEEE802154_TELINK_B91

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -38,11 +38,19 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 static struct b91_src_match_table src_match_table;
 #endif /* CONFIG_OPENTHREAD_FTD */
 
+#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+/* B91 radio source match table structure */
+static struct b91_enh_ack_table enh_ack_table;
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
+
 /* B91 data structure */
 static struct  b91_data data = {
 #ifdef CONFIG_OPENTHREAD_FTD
-	.src_match_table = &src_match_table
+	.src_match_table = &src_match_table,
 #endif /* CONFIG_OPENTHREAD_FTD */
+#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+	.enh_ack_table = &enh_ack_table,
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 };
 
 #ifdef CONFIG_OPENTHREAD_FTD
@@ -55,12 +63,12 @@ static void b91_src_match_table_clean(struct b91_src_match_table *table)
 
 /* Search in radio search match table */
 static bool
-inline b91_src_match_table_search(
+ALWAYS_INLINE b91_src_match_table_search(
 	const struct b91_src_match_table *table, const uint8_t *addr, bool ext)
 {
 	bool result = false;
 
-	for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
+	for (size_t i = 0; i < 2 * CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
 		if (table->item[i].valid && table->item[i].ext == ext &&
 			!memcmp(table->item[i].addr, addr,
 				ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
@@ -78,13 +86,13 @@ static void b91_src_match_table_add(
 	struct b91_src_match_table *table, const uint8_t *addr, bool ext)
 {
 	if (!b91_src_match_table_search(table, addr, ext)) {
-		for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
+		for (size_t i = 0; i < 2 * CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
 			if (!table->item[i].valid) {
-				table->item[i].valid = true;
 				table->item[i].ext = ext;
 				memcpy(table->item[i].addr, addr,
 					ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
 					IEEE802154_FRAME_LENGTH_ADDR_SHORT);
+				table->item[i].valid = true;
 				break;
 			}
 		}
@@ -95,7 +103,7 @@ static void b91_src_match_table_add(
 static void b91_src_match_table_remove(
 	struct b91_src_match_table *table, const uint8_t *addr, bool ext)
 {
-	for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
+	for (size_t i = 0; i < 2 * CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
 		if (table->item[i].valid && table->item[i].ext == ext &&
 			!memcmp(table->item[i].addr, addr,
 				ext ? IEEE802154_FRAME_LENGTH_ADDR_EXT :
@@ -113,7 +121,7 @@ static void b91_src_match_table_remove(
 /* Remove all entries from radio search match table */
 static void b91_src_match_table_remove_group(struct b91_src_match_table *table, bool ext)
 {
-	for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
+	for (size_t i = 0; i < 2 * CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
 		if (table->item[i].valid && table->item[i].ext == ext) {
 			table->item[i].valid = false;
 			table->item[i].ext = false;
@@ -127,10 +135,10 @@ static void b91_src_match_table_remove_group(struct b91_src_match_table *table, 
 /*
  * Check frame possible require to set pending bit
  * data request command or data
- * buffer should be valid
+ * frame should be valid
  */
 static bool
-inline b91_require_pending_bit(const struct ieee802154_frame *frame)
+ALWAYS_INLINE b91_require_pending_bit(const struct ieee802154_frame *frame)
 {
 	bool result = false;
 
@@ -147,6 +155,87 @@ inline b91_require_pending_bit(const struct ieee802154_frame *frame)
 }
 
 #endif /* CONFIG_OPENTHREAD_FTD */
+
+#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+
+/* clean radio search match table */
+static void b91_enh_ack_table_clean(struct b91_enh_ack_table *table)
+{
+	memset(table, 0, sizeof(struct b91_enh_ack_table));
+}
+
+/* Search in enhanced ack table */
+static int
+ALWAYS_INLINE b91_enh_ack_table_search(
+	const struct b91_enh_ack_table *table, const uint8_t *addr_short, const uint8_t *addr_ext)
+{
+	int result = -1;
+
+	for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
+		if (table->item[i].valid &&
+			(!memcmp(table->item[i].addr_short, addr_short,
+				IEEE802154_FRAME_LENGTH_ADDR_SHORT) ||
+			!memcmp(table->item[i].addr_ext, addr_ext,
+				IEEE802154_FRAME_LENGTH_ADDR_EXT))) {
+			result = i;
+			break;
+		}
+	}
+
+	return result;
+}
+
+/* Add to enhanced ack table */
+static void b91_enh_ack_table_add(
+	struct b91_enh_ack_table *table, const uint8_t *addr_short, const uint8_t *addr_ext,
+	uint16_t ie_header_len, const uint8_t *ie_header)
+{
+	int idx = b91_enh_ack_table_search(table, addr_short, addr_ext);
+
+	if (idx == -1) {
+		for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
+			if (!table->item[i].valid) {
+				idx = i;
+				memcpy(table->item[idx].addr_short, addr_short,
+					IEEE802154_FRAME_LENGTH_ADDR_SHORT);
+				memcpy(table->item[idx].addr_ext, addr_ext,
+					IEEE802154_FRAME_LENGTH_ADDR_EXT);
+				table->item[idx].valid = true;
+				break;
+			}
+		}
+	}
+	if (idx != -1) {
+		table->item[idx].ie_header_len = ie_header_len;
+		memcpy(table->item[idx].ie_header, ie_header,
+			ie_header_len);
+	}
+}
+
+/* Remove from enhanced ack table */
+static void b91_enh_ack_table_remove(
+	struct b91_enh_ack_table *table, const uint8_t *addr_short, const uint8_t *addr_ext)
+{
+	for (size_t i = 0; i < CONFIG_OPENTHREAD_MAX_CHILDREN; i++) {
+		if (table->item[i].valid &&
+			!memcmp(table->item[i].addr_short, addr_short,
+				IEEE802154_FRAME_LENGTH_ADDR_SHORT) &&
+			!memcmp(table->item[i].addr_ext, addr_ext,
+				IEEE802154_FRAME_LENGTH_ADDR_EXT)) {
+			table->item[i].valid = false;
+			memset(table->item[i].addr_short, 0,
+				IEEE802154_FRAME_LENGTH_ADDR_SHORT);
+			memset(table->item[i].addr_ext, 0,
+				IEEE802154_FRAME_LENGTH_ADDR_EXT);
+			table->item[i].ie_header_len = 0;
+			memset(table->item[i].ie_header, 0,
+				B91_ACK_IE_MAX_SIZE);
+			break;
+		}
+	}
+}
+
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 
 /* Disable power management by device */
 static void b91_disable_pm(const struct device *dev)
@@ -208,7 +297,7 @@ static int b91_set_ieee_addr(const uint8_t *ieee_addr)
 
 /* Filter PAN ID, short address and IEEE address */
 static bool
-inline b91_run_filter(const struct ieee802154_frame *frame)
+ALWAYS_INLINE b91_run_filter(const struct ieee802154_frame *frame)
 {
 	bool result = false;
 
@@ -245,7 +334,7 @@ inline b91_run_filter(const struct ieee802154_frame *frame)
 }
 
 /* Get MAC address */
-static inline uint8_t *b91_get_mac(const struct device *dev)
+static ALWAYS_INLINE uint8_t *b91_get_mac(const struct device *dev)
 {
 	struct b91_data *b91 = dev->data;
 
@@ -281,7 +370,7 @@ static inline uint8_t *b91_get_mac(const struct device *dev)
 
 /* Convert RSSI to LQI */
 static uint8_t
-inline b91_convert_rssi_to_lqi(int8_t rssi)
+ALWAYS_INLINE b91_convert_rssi_to_lqi(int8_t rssi)
 {
 	uint32_t lqi32 = 0;
 
@@ -303,7 +392,7 @@ inline b91_convert_rssi_to_lqi(int8_t rssi)
 
 /* Update RSSI and LQI parameters */
 static void
-inline b91_update_rssi_and_lqi(struct net_pkt *pkt)
+ALWAYS_INLINE b91_update_rssi_and_lqi(struct net_pkt *pkt)
 {
 	int8_t rssi;
 	uint8_t lqi;
@@ -318,7 +407,7 @@ inline b91_update_rssi_and_lqi(struct net_pkt *pkt)
 
 /* Prepare TX buffer */
 static void
-inline b91_set_tx_payload(uint8_t *payload, uint8_t payload_len)
+ALWAYS_INLINE b91_set_tx_payload(uint8_t *payload, uint8_t payload_len)
 {
 	unsigned char rf_data_len;
 	unsigned int rf_tx_dma_len;
@@ -335,7 +424,7 @@ inline b91_set_tx_payload(uint8_t *payload, uint8_t payload_len)
 
 /* Handle acknowledge packet */
 static void
-inline b91_handle_ack(const void *buf, size_t buf_len)
+ALWAYS_INLINE b91_handle_ack(const void *buf, size_t buf_len)
 {
 	struct net_pkt *ack_pkt = net_pkt_alloc_with_buffer(
 		data.iface, buf_len, AF_UNSPEC, 0, K_NO_WAIT);
@@ -364,7 +453,7 @@ inline b91_handle_ack(const void *buf, size_t buf_len)
 
 /* Send acknowledge packet */
 static void
-inline b91_send_ack(const struct ieee802154_frame *frame)
+ALWAYS_INLINE b91_send_ack(const struct ieee802154_frame *frame)
 {
 	uint8_t ack_buf[64];
 	size_t ack_len;
@@ -382,9 +471,7 @@ inline b91_send_ack(const struct ieee802154_frame *frame)
 }
 
 /* RX IRQ handler */
-static void
-__attribute__((section(".ram_code")))
-b91_rf_rx_isr(void)
+static void ALWAYS_INLINE b91_rf_rx_isr(void)
 {
 	int status = -EINVAL;
 	struct net_pkt *pkt = NULL;
@@ -439,7 +526,36 @@ b91_rf_rx_isr(void)
 					}
 				}
 			}
-#endif
+#endif /* CONFIG_OPENTHREAD_FTD */
+#if CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+			int idx = -1;
+
+			if (frame.general.ver == IEEE802154_FRAME_FCF_VER_2015) {
+				idx = b91_enh_ack_table_search(data.enh_ack_table,
+					frame.src_addr_ext ? NULL : frame.src_addr,
+					frame.src_addr_ext ? frame.src_addr : NULL);
+			}
+			const struct ieee802154_frame ack_frame = {
+				.general = {
+					.valid = true,
+					.ver = idx == -1 ? IEEE802154_FRAME_FCF_VER_2003 :
+						IEEE802154_FRAME_FCF_VER_2015,
+					.type = IEEE802154_FRAME_FCF_TYPE_ACK,
+					.fp_bit = frame_pending
+				},
+				.sn = frame.sn,
+				.dst_panid = idx == -1 ? NULL :
+					(frame.src_panid ? frame.src_panid : frame.dst_panid),
+				.dst_addr = idx == -1 ? NULL :
+					frame.src_addr,
+				.dst_addr_ext = idx == -1 ? false :
+					frame.src_addr_ext,
+				.ie_header = idx == -1 ? NULL :
+					data.enh_ack_table->item[idx].ie_header,
+				.ie_header_len = idx == -1 ? 0 :
+					data.enh_ack_table->item[idx].ie_header_len
+			};
+#else
 			const struct ieee802154_frame ack_frame = {
 				.general = {
 					.valid = true,
@@ -449,6 +565,7 @@ b91_rf_rx_isr(void)
 				},
 				.sn = frame.sn
 			};
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 			b91_send_ack(&ack_frame);
 		}
 		pkt = net_pkt_alloc_with_buffer(data.iface, length, AF_UNSPEC, 0, K_NO_WAIT);
@@ -475,7 +592,7 @@ b91_rf_rx_isr(void)
 }
 
 /* TX IRQ handler */
-static void b91_rf_tx_isr(void)
+static ALWAYS_INLINE void b91_rf_tx_isr(void)
 {
 	/* clear irq status */
 	rf_clr_irq_status(FLD_RF_IRQ_TX);
@@ -491,7 +608,7 @@ static void b91_rf_tx_isr(void)
 }
 
 /* IRQ handler */
-static void b91_rf_isr(void)
+static void __GENERIC_SECTION(.ram_code) b91_rf_isr(void)
 {
 	if (rf_get_irq_status(FLD_RF_IRQ_RX)) {
 		b91_rf_rx_isr();
@@ -535,7 +652,9 @@ static int b91_init(const struct device *dev)
 #ifdef CONFIG_OPENTHREAD_FTD
 	b91_src_match_table_clean(b91->src_match_table);
 #endif /* CONFIG_OPENTHREAD_FTD */
-
+#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+	b91_enh_ack_table_clean(b91->enh_ack_table);
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 	return 0;
 }
 
@@ -766,7 +885,6 @@ static int b91_configure(const struct device *dev,
 		}
 		break;
 	case IEEE802154_CONFIG_ACK_FPB:
-		riscv_plic_irq_disable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
 		if (config->ack_fpb.addr) {
 			if (config->ack_fpb.enabled) {
 				b91_src_match_table_add(b91->src_match_table,
@@ -781,9 +899,29 @@ static int b91_configure(const struct device *dev,
 		} else {
 			result = -ENOTSUP;
 		}
-		riscv_plic_irq_enable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
 		break;
 #endif /* CONFIG_OPENTHREAD_FTD */
+#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE:
+		{
+			uint8_t short_addr[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
+			uint8_t ext_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
+
+			sys_put_le16(config->ack_ie.short_addr, short_addr);
+			sys_memcpy_swap(ext_addr, config->ack_ie.ext_addr,
+				IEEE802154_FRAME_LENGTH_ADDR_EXT);
+			if (config->ack_ie.data_len > 0) {
+				b91_enh_ack_table_add(b91->enh_ack_table,
+					short_addr, ext_addr,
+					config->ack_ie.data_len, config->ack_ie.data);
+			} else {
+				b91_enh_ack_table_remove(b91->enh_ack_table,
+					short_addr, ext_addr);
+			}
+		}
+		break;
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
+
 	default:
 		result = -ENOTSUP;
 		break;

--- a/drivers/ieee802154/ieee802154_b91.h
+++ b/drivers/ieee802154/ieee802154_b91.h
@@ -36,6 +36,8 @@
 #define B91_RSSI_TO_LQI_MIN                 (-87)
 #define B91_CCA_TIME_MAX_US                 (200)
 #define B91_LOGIC_CHANNEL_TO_PHYSICAL(p)    (((p) - 10) * 5)
+#define B91_ACK_IE_MAX_SIZE					(16)
+
 
 /* TX power lookup table */
 #define B91_TX_POWER_MIN                    (-30)
@@ -92,9 +94,22 @@ struct b91_src_match_table {
 		bool ext;
 		uint8_t addr[MAX(IEEE802154_FRAME_LENGTH_ADDR_EXT,
 			IEEE802154_FRAME_LENGTH_ADDR_SHORT)];
-	} item[CONFIG_OPENTHREAD_MAX_CHILDREN];
+	} item[2 * CONFIG_OPENTHREAD_MAX_CHILDREN];
 };
 #endif /* CONFIG_OPENTHREAD_FTD */
+
+#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+/* radio source match table type */
+struct b91_enh_ack_table {
+	struct {
+		bool valid;
+		uint8_t addr_short[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
+		uint8_t addr_ext[IEEE802154_FRAME_LENGTH_ADDR_EXT];
+		uint16_t ie_header_len;
+		uint8_t ie_header[B91_ACK_IE_MAX_SIZE];
+	} item[CONFIG_OPENTHREAD_MAX_CHILDREN];
+};
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 
 /* data structure */
 struct b91_data {
@@ -112,7 +127,12 @@ struct b91_data {
 	uint16_t current_channel;
 	int16_t current_dbm;
 	volatile bool ack_sending;
+#ifdef CONFIG_OPENTHREAD_FTD
 	struct b91_src_match_table *src_match_table;
+#endif /* CONFIG_OPENTHREAD_FTD */
+#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+	struct b91_enh_ack_table *enh_ack_table;
+#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #ifdef CONFIG_PM_DEVICE
 	atomic_t current_pm_lock;
 #endif /* CONFIG_PM_DEVICE */

--- a/drivers/ieee802154/ieee802154_b91_frame.c
+++ b/drivers/ieee802154/ieee802154_b91_frame.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+#include <zephyr/toolchain/common.h>
 
 
 /* frame control field byte 0 */
@@ -119,7 +120,7 @@ struct ieee802154_frame {
  * fcf should be valid and contains at lest 2 bytes
  */
 static bool
-inline ieee802154_frame_has_dest_panid(const uint8_t fcf[2])
+ALWAYS_INLINE ieee802154_frame_has_dest_panid(const uint8_t fcf[2])
 {
 	bool result = true;
 	const uint8_t frame_ver_t = (fcf[1] & IEEE802154_FRAME_FCF_VER_MASK) >>
@@ -169,7 +170,7 @@ inline ieee802154_frame_has_dest_panid(const uint8_t fcf[2])
  * frame should be valid
  */
 static bool
-inline ieee802154_frame_panid_compression(const struct ieee802154_frame *frame)
+ALWAYS_INLINE ieee802154_frame_panid_compression(const struct ieee802154_frame *frame)
 {
 	bool result = false;
 
@@ -211,7 +212,7 @@ inline ieee802154_frame_panid_compression(const struct ieee802154_frame *frame)
  * buf & frame should be valid
  */
 static void
-inline b91_ieee802154_frame_parse(const uint8_t *buf, size_t bul_len,
+ALWAYS_INLINE b91_ieee802154_frame_parse(const uint8_t *buf, size_t bul_len,
 	struct ieee802154_frame *frame)
 {
 	size_t pos = 0; /* current buffer position */
@@ -463,7 +464,7 @@ inline b91_ieee802154_frame_parse(const uint8_t *buf, size_t bul_len,
  * frame & buf should be valid
  */
 static bool
-inline b91_ieee802154_frame_build(const struct ieee802154_frame *frame,
+ALWAYS_INLINE b91_ieee802154_frame_build(const struct ieee802154_frame *frame,
 	uint8_t *buf, size_t bul_len, size_t *o_len)
 {
 	bool result = false;


### PR DESCRIPTION
Thread v1.2 or newer supports link metrics feature. This feature requires extended ACK response using 2015 frame format.

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>