### PR TITLE
drivers: ieee802154: telink: Enable source match table at init

### DIFF
--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -651,6 +651,7 @@ static int b91_init(const struct device *dev)
 	data.current_dbm = 0x7FFF;
 #ifdef CONFIG_OPENTHREAD_FTD
 	b91_src_match_table_clean(b91->src_match_table);
+	b91->src_match_table->enabled = true;
 #endif /* CONFIG_OPENTHREAD_FTD */
 #ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
 	b91_enh_ack_table_clean(b91->enh_ack_table);


### PR DESCRIPTION
First ACK response to SED should be without frame pending bit.
But after reset table was disable and we responded with pending bit.

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>