### PR TITLE
hal: telink: B91 BT FIFO size dependencies fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -130,7 +130,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: db730e20ec83a0e47d2cfb518d7d55e5ee96789b
+      revision: 604f2c3f7a650e8a0dd8d6e21a20c3432509e45f
       path: modules/hal/telink
       submodules: true
       groups:


### PR DESCRIPTION
After [Zephyr Power Management Functionality](https://github.com/zephyrproject-rtos/hal_telink/pull/5 ) had been added, some changes in tlsr9/ble/vendor/controller/**b91_bt_buffer**.h led to **SMP server sample** failure because earlier in **bt-overlay.conf** parameters sizes of FIFO were ignored.