### PR TITLE
west.yml: telink_b91: Use zephyr blob scheme

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -135,7 +135,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 9bd7ef53b5ba9063cd724afbe87f198e760d29a4
+      revision: de7557c7981a7e8c1a1ef60504c4557bed7608da
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Update hal_telink module revision.

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>