### PR TITLE
boards: tlsr9518adk80d: soc: telink_b91: init.ld: Fix mcuboot

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
@@ -104,15 +104,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x00000000 0x18000>;
 		};
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@18000 {
 			label = "image-0";
-			reg = <0x10000 0x70000>;
+			reg = <0x18000 0x6C000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@84000 {
 			label = "image-1";
-			reg = <0x80000 0x70000>;
+			reg = <0x84000 0x6C0000>;
 		};
 		scratch_partition: partition@f0000 {
 			label = "image-scratch";

--- a/soc/riscv/riscv-privilege/telink_b91/init.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/init.ld
@@ -4,4 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+. += CONFIG_ROM_START_OFFSET;
 KEEP(*(.init.*))


### PR DESCRIPTION
ROM_START_OFFSET config which is set by BOOTLOADER_MCUBOOT config was no longer taken into account by linker script.
MCUBoot is no longer suitable to 64 KB so application images partitions updated. Partitions base addresses:
slot0: 0x18000
slot1: 0x84000
both have sizes 0x6C000 - 432KB

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>