### PR TITLE
boards: tlsr9518adk80d: Check binaries size for mcuboot

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_defconfig
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_defconfig
@@ -14,3 +14,7 @@ CONFIG_UART_CONSOLE=y
 
 # HW DSP options
 CONFIG_TELINK_B91_HWDSP=n
+
+# MCU boot application options
+CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"
+CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS="--max-sectors 4096"

--- a/soc/riscv/riscv-privilege/telink_b91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/linker.ld
@@ -17,3 +17,7 @@ MEMORY
 }
 
 #include <zephyr/arch/riscv/common/linker.ld>
+
+#ifdef CONFIG_MCUBOOT
+	ASSERT(__rom_region_size <= DT_REG_SIZE(DT_NODELABEL(boot_partition)), "boot_partition overflows")
+#endif


### PR DESCRIPTION
During building mcuboot added checker for output binary size. Mcuboot binary should be suitable to its partition - boot_partition. Application binary size is checked during signing stage. In that case additional option should be provided to west sign command: --max-sectors 4096
Signed image is created during build when CONFIG_BOOTLOADER_MCUBOOT is set.

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>