### PR TITLE
soc: riscv: telink_b91: Disable USB SWI

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b91/start.S
+++ b/soc/riscv/riscv-privilege/telink_b91/start.S
@@ -31,11 +31,17 @@ entry:
 
 start:
 
+	/* USB SWI disable: 0x80100c01 <- 0x40 */
+	lui    t0, 0x80100
+	addi   t0, t0, 0x700
+	li     t1, 0x40
+	sb     t1, 0x501(t0)
+
 	/* Enable I/D-Cache */
-	csrr   t0,  NDS_MCACHE_CTL
-	ori    t0,  t0,  1        #/I-Cache
-	ori    t0,  t0,  2        #/D-Cache
-	csrw   NDS_MCACHE_CTL,  t0
+	csrr   t0, NDS_MCACHE_CTL
+	ori    t0, t0,  1        #/I-Cache
+	ori    t0, t0,  2        #/D-Cache
+	csrw   NDS_MCACHE_CTL, t0
 	fence.i
 
 	/* Enable misaligned access and non-blocking load */


### PR DESCRIPTION
SWI USB interface enabled by default. When Dp and Dm are used as GPIO
it has a risk to trigger the SWI through USB function to do something
unexpected.

Signed-off-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>