### PR TITLE
soc: riscv: telink_b91: BLE PM improvements

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b91/power.c
+++ b/soc/riscv/riscv-privilege/telink_b91/power.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ext_driver/ext_pm.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/pm.h>
 #include <stimer.h>
+#include <b91_sleep.h>
 #include <zephyr/kernel.h>
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
@@ -96,10 +96,11 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			if (stimer_sleep_ticks > SYSTICKS_MAX_SLEEP) {
 				stimer_sleep_ticks = SYSTICKS_MAX_SLEEP;
 			}
-			cpu_sleep_wakeup_32k_rc(SUSPEND_MODE, PM_WAKEUP_TIMER,
-						tl_sleep_tick + stimer_sleep_ticks);
-			current_time += systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
-			set_mtime(current_time);
+			if (b91_suspend(tl_sleep_tick + stimer_sleep_ticks)) {
+				current_time +=
+					systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
+				set_mtime(current_time);
+			}
 		}
 		break;
 

--- a/soc/riscv/riscv-privilege/telink_b91/soc.c
+++ b/soc/riscv/riscv-privilege/telink_b91/soc.c
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sys.h"
-#include "clock.h"
+#include <sys.h>
+#include <clock.h>
+#include <gpio_default.h>
+#include <ext_driver/ext_pm.h>
 #include <zephyr/device.h>
+
 
 /* Software reset defines */
 #define reg_reset                   REG_ADDR8(0x1401ef)
@@ -76,8 +79,18 @@ static int soc_b91_init(const struct device *arg)
 
 	ARG_UNUSED(arg);
 
+#if (defined(CONFIG_PM) && defined(CONFIG_BT_B91))
+	/* Select internal 32K for BLE PM, ASAP after boot */
+	blc_pm_select_internal_32k_crystal();
+#endif /* CONFIG_PM && CONFIG_BT_B91 */
+
 	/* system init */
 	sys_init(POWER_MODE, VBAT_TYPE);
+
+#if CONFIG_PM
+	/* set GPIOs to default state */
+	gpio_init(1);
+#endif /* CONFIG_PM */
 
 	/* clocks init: CCLK, HCLK, PCLK */
 	switch (cclk) {

--- a/west.yml
+++ b/west.yml
@@ -135,7 +135,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: de7557c7981a7e8c1a1ef60504c4557bed7608da
+      revision: dbe339c95efc8adef1e6ad19c60af1e90312bb81
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- Switch off unused GPIO
- Allow BLE stack to control entering suspend mode

Co-authored-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>
Signed-off-by: Qiu Gao <qiu.gao@telink-semi.com>