### PR TITLE
drivers: telink_b91: Remove zephyr.h header

### DIFF
--- a/drivers/usb/device/usb_dc_b91.c
+++ b/drivers/usb/device/usb_dc_b91.c
@@ -16,7 +16,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/onoff.h>
 #include <zephyr/usb/usb_device.h>
-#include <zephyr/zephyr.h>
 
 #include <soc.h>
 


### PR DESCRIPTION
Since zephyr.h header is deprecated it should be removed. kernel.h should be used instead.

Signed-off-by: Krystian Jankowski <krystian.jankowski@telink-semi.com>