### PR TITLE
soc: riscv: telink_b91: Disable USB SWI by default

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     concurrency:
       group: doc-build-html-${{ github.ref }}
@@ -48,7 +48,7 @@ jobs:
     - name: install-pkgs
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build graphviz libclang1-9 libclang-cpp9
+        sudo apt-get install -y ninja-build graphviz
         wget --no-verbose https://downloads.sourceforge.net/project/doxygen/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
@@ -115,6 +115,7 @@ jobs:
 
   doc-build-pdf:
     name: "Documentation Build (PDF)"
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
     container: texlive/texlive:latest
     timeout-minutes: 45

--- a/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Copyright (c) 2021 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+if (CONFIG_TELINK_B91_USB_SWI_ENABLE)
+	message(STATUS "USB SWI interface is enabled")
+endif()
+
 zephyr_sources(
 	start.S
 	soc_irq.S

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
@@ -81,4 +81,8 @@ config STACK_SENTINEL
 config THREAD_NAME
 	default y if STACK_SENTINEL
 
+config TELINK_B91_USB_SWI_ENABLE
+	bool
+	default n
+
 endif # SOC_SERIES_RISCV_TELINK_B91

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -67,3 +67,10 @@ config TELINK_B91_REBOOT_ON_FAULT_DELAY
 	range 0 30000
 	help
 		This option sets Telink B91 chip reboot on fault delay in mS.
+
+config TELINK_B91_USB_SWI_ENABLE
+	bool "Use USB SWI interface"
+	depends on SOC_SERIES_RISCV_TELINK_B91
+	default n
+	help
+		This option enables USB SWI interface

--- a/soc/riscv/riscv-privilege/telink_b91/start.S
+++ b/soc/riscv/riscv-privilege/telink_b91/start.S
@@ -31,11 +31,13 @@ entry:
 
 start:
 
+#if !defined(CONFIG_TELINK_B91_USB_SWI_ENABLE) || !CONFIG_TELINK_B91_USB_SWI_ENABLE
 	/* USB SWI disable: 0x80100c01 <- 0x40 */
 	lui    t0, 0x80100
 	addi   t0, t0, 0x700
 	li     t1, 0x40
 	sb     t1, 0x501(t0)
+#endif
 
 	/* Enable I/D-Cache */
 	csrr   t0, NDS_MCACHE_CTL


### PR DESCRIPTION
USB SWI is disabled by default.
To enable it CONFIG_TELINK_B91_USB_SWI_ENABLE must be defined.