### PR TITLE
Set 4-wire SPI by default

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
@@ -5,6 +5,10 @@ if (CONFIG_TELINK_B91_USB_SWI_ENABLE)
 	message(STATUS "USB SWI interface is enabled")
 endif()
 
+if (CONFIG_TELINK_B91_2_WIRE_SPI_ENABLE)
+	message(WARNING "2-wire SPI interface enabled!")
+endif()
+
 zephyr_sources(
 	start.S
 	soc_irq.S

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
@@ -85,4 +85,8 @@ config TELINK_B91_USB_SWI_ENABLE
 	bool
 	default n
 
+config TELINK_B91_2_WIRE_SPI_ENABLE
+	bool
+	default n
+
 endif # SOC_SERIES_RISCV_TELINK_B91

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -74,3 +74,10 @@ config TELINK_B91_USB_SWI_ENABLE
 	default n
 	help
 		This option enables USB SWI interface
+
+config TELINK_B91_2_WIRE_SPI_ENABLE
+	bool "Use 2-wire SPI interface to FLASH"
+	depends on SOC_SERIES_RISCV_TELINK_B91
+	default n
+	help
+		This option enables 2-wire SPI interface to FLASH

--- a/soc/riscv/riscv-privilege/telink_b91/start.S
+++ b/soc/riscv/riscv-privilege/telink_b91/start.S
@@ -25,7 +25,11 @@ entry:
 	.word ('T'<<24 | 'L'<<16 | 'N'<<8 | 'K')
 
 	.org 0x26
-	.short (0x173B)
+#if defined(CONFIG_TELINK_B91_2_WIRE_SPI_ENABLE) && CONFIG_TELINK_B91_2_WIRE_SPI_ENABLE
+	.short (0x173B)		/* 2 - wire SPI interface */
+#else
+	.short (0x65EB)		/* 4 - wire SPI interface */
+#endif
 
 	.align 2
 


### PR DESCRIPTION
It changes 2-wire SPI to 4-wire SPI interface and set it as the default one.
It can be changed by setting CONFIG_TELINK_B91_2_WIRE_SPI_ENABLE option.