### PR TITLE
soc: riscv: telink: GPIO shutdown at startup

### DIFF
--- a/.github/workflows/demo_apps_build.yaml
+++ b/.github/workflows/demo_apps_build.yaml
@@ -51,7 +51,8 @@ jobs:
 
             - name: Install dependencies
               run: |
-                    sudo apt-get install -fy --no-install-recommends ninja-build cmake make gcc gcc-multilib g++-multilib libsdl2-dev
+                    sudo apt-get update \
+                    && sudo apt-get install -fy --no-install-recommends ninja-build cmake make gcc gcc-multilib g++-multilib libsdl2-dev
 
             - name: Setup toolchain
               run: |

--- a/soc/riscv/riscv-privilege/telink_b91/soc.c
+++ b/soc/riscv/riscv-privilege/telink_b91/soc.c
@@ -6,7 +6,7 @@
 
 #include <sys.h>
 #include <clock.h>
-#include <gpio_default.h>
+#include <gpio.h>
 #include <ext_driver/ext_pm.h>
 #include <zephyr/device.h>
 
@@ -88,8 +88,7 @@ static int soc_b91_init(const struct device *arg)
 	sys_init(POWER_MODE, VBAT_TYPE);
 
 #if CONFIG_PM
-	/* set GPIOs to default state */
-	gpio_init(1);
+	gpio_shutdown(GPIO_ALL);
 #endif /* CONFIG_PM */
 
 	/* clocks init: CCLK, HCLK, PCLK */


### PR DESCRIPTION
Use gpio_shutdown instead of gpio_init for better power consumption in suspend mode.