### PR TITLE
soc: riscv: telink_b91: USB SWI enabled by default

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright (c) 2021 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-if (CONFIG_TELINK_B91_USB_SWI_ENABLE)
-	message(STATUS "USB SWI interface is enabled")
+if (CONFIG_TELINK_B91_USB_SWI_DISABLE)
+	message(STATUS "USB SWI interface is disabled")
 endif()
 
 if (CONFIG_TELINK_B91_2_WIRE_SPI_ENABLE)

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
@@ -81,7 +81,7 @@ config STACK_SENTINEL
 config THREAD_NAME
 	default y if STACK_SENTINEL
 
-config TELINK_B91_USB_SWI_ENABLE
+config TELINK_B91_USB_SWI_DISABLE
 	bool
 	default n
 

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -68,12 +68,12 @@ config TELINK_B91_REBOOT_ON_FAULT_DELAY
 	help
 		This option sets Telink B91 chip reboot on fault delay in mS.
 
-config TELINK_B91_USB_SWI_ENABLE
-	bool "Use USB SWI interface"
+config TELINK_B91_USB_SWI_DISABLE
+	bool "Don't use USB SWI interface"
 	depends on SOC_SERIES_RISCV_TELINK_B91
 	default n
 	help
-		This option enables USB SWI interface
+		This option disables USB SWI interface
 
 config TELINK_B91_2_WIRE_SPI_ENABLE
 	bool "Use 2-wire SPI interface to FLASH"

--- a/soc/riscv/riscv-privilege/telink_b91/start.S
+++ b/soc/riscv/riscv-privilege/telink_b91/start.S
@@ -35,7 +35,7 @@ entry:
 
 start:
 
-#if !defined(CONFIG_TELINK_B91_USB_SWI_ENABLE) || !CONFIG_TELINK_B91_USB_SWI_ENABLE
+#if defined(CONFIG_TELINK_B91_USB_SWI_DISABLE) && CONFIG_TELINK_B91_USB_SWI_DISABLE
 	/* USB SWI disable: 0x80100c01 <- 0x40 */
 	lui    t0, 0x80100
 	addi   t0, t0, 0x700


### PR DESCRIPTION
It enables USB SWI by default. 
In case of USB SWI should be disabled then CONFIG_TELINK_B91_USB_SWI_DISABLE must be defined and set.