### PR TITLE
drivers: bluetooth: telink: Add stop Bluetooth API

### DIFF
--- a/drivers/bluetooth/hci/hci_b91.c
+++ b/drivers/bluetooth/hci/hci_b91.c
@@ -231,9 +231,18 @@ static int hci_b91_open(void)
 	return 0;
 }
 
+static int hci_b91_close(void)
+{
+	bt_le_adv_stop();
+	b91_bt_controller_deinit();
+
+	return 0;
+}
+
 static const struct bt_hci_driver drv = {
 	.name   = "BT B91",
 	.open   = hci_b91_open,
+	.close	= hci_b91_close,
 	.send   = bt_b91_send,
 	.bus    = BT_HCI_DRIVER_BUS_IPM,
 #if defined(CONFIG_BT_DRIVER_QUIRK_NO_AUTO_DLE)

--- a/west.yml
+++ b/west.yml
@@ -135,7 +135,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: cfdf594709c8bdff9c62491807b0d1e2f3f9250f
+      revision: 3730a205dca58984a5b23d20615fd0b0d5886869
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Added possibility to start/stop Bluetooth interface during runtime. Now high level APIs bt_enable/bt_disable are working on Telink platform.