### PR TITLE
soc: telink_b91: Kconfig.soc: Disable SHELL_BACKENDS if PM

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -53,6 +53,9 @@ config FLASH_BASE_ADDRESS
 config PM_DEVICE
 	default y if PM
 
+config SHELL_BACKENDS
+	default n if PM
+
 config TELINK_B91_REBOOT_ON_FAULT
 	bool "Reboot system when fault happened"
 	depends on SOC_SERIES_RISCV_TELINK_B91


### PR DESCRIPTION
Telink B91 chip puts peripheral down during entering suspend mode. In that case its not able to receive income data. So when PM is enabled all back-ends should be disabled because it's not possible to issue commands.