### PR TITLE
drivers: ieee802154: telink: Set radio mode only when required

### DIFF
--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -922,8 +922,6 @@ static int b91_set_channel(const struct device *dev, uint16_t channel)
 		b91->current_channel = channel;
 		if (b91->is_started) {
 			rf_set_chn(B91_LOGIC_CHANNEL_TO_PHYSICAL(channel));
-			rf_set_txmode();
-			rf_set_rxmode();
 		}
 	}
 
@@ -992,6 +990,7 @@ static int b91_start(const struct device *dev)
 		rf_set_zigbee_250K_mode();
 		rf_set_tx_dma(1, B91_TRX_LENGTH);
 		rf_set_rx_dma(b91->rx_buffer, 0, B91_TRX_LENGTH);
+		rf_set_tx_rx_off();
 		if (b91->current_channel != B91_TX_CH_NOT_SET) {
 			rf_set_chn(B91_LOGIC_CHANNEL_TO_PHYSICAL(b91->current_channel));
 		}
@@ -1000,8 +999,6 @@ static int b91_start(const struct device *dev)
 		}
 		rf_set_irq_mask(FLD_RF_IRQ_RX | FLD_RF_IRQ_TX);
 		riscv_plic_irq_enable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
-		rf_set_txmode();
-		rf_set_rxmode();
 		b91->is_started = true;
 	}
 


### PR DESCRIPTION
At start radio is off.
During all transmission radio sets to TX mode.
At finalize transmission or timeout it sets to RX mode.