### PR TITLE
drivers: gpio: fixed interrupts on buttons

### DIFF
--- a/boards/riscv/tlsr9528a/tlsr9528a.dts
+++ b/boards/riscv/tlsr9528a/tlsr9528a.dts
@@ -131,11 +131,11 @@
 };
 
 &gpioc {
-	interrupts = <37 1>;
 	status = "okay";
 };
 
 &gpiod {
+	interrupts = <37 1>;
 	status = "okay";
 };
 

--- a/dts/riscv/telink/telink_b92.dtsi
+++ b/dts/riscv/telink/telink_b92.dtsi
@@ -148,7 +148,7 @@
 					0xe4200000 0x00010000 >;
 			reg-names = "prio", "irq_en", "reg";
 			riscv,max-priority = <3>;
-			riscv,ndev = <63>;
+			riscv,ndev = <46>;
 		};
 
 		uart0: serial@80140080 {


### PR DESCRIPTION
Modified B92 DTS so port D buttons work now.
As per datasheet changed interrupts number 63->46