### PR TITLE
drivers: usb: b91: Remove redundant arg param

### DIFF
--- a/drivers/usb/device/usb_dc_b91.c
+++ b/drivers/usb/device/usb_dc_b91.c
@@ -1726,7 +1726,7 @@ static void usbd_work_handler(struct k_work *item)
 	}
 }
 
-static int usb_init(const struct device *arg)
+static int usb_init(void)
 {
 	int ret;
 


### PR DESCRIPTION
Since arg parameter is not used in usb_init function it can be removed, but what more stays behind this, that init function in SYS_INIT must be in form of "int (*sys)(void)" without using parameter. Otherwise compiler reports warnings.