### PR TITLE
Telink enable 4wire-SPI interface on B92

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b9x/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b9x/Kconfig.defconfig.series
@@ -94,7 +94,7 @@ endif # SOC_RISCV_TELINK_B91
 if SOC_RISCV_TELINK_B92
 config TELINK_B9X_2_WIRE_SPI_ENABLE
 	bool
-	default y
+	default n
 endif # SOC_RISCV_TELINK_B92
 
 endif # SOC_SERIES_RISCV_TELINK_B9X


### PR DESCRIPTION
Changed default setting for 4wire-spi.
IMPORTANT: EVK might need to be flashed with activator-binary first. Otherwise it freezes in startup
(more info in ZEPHYR-360)