### PR TITLE
soc: riscv: telink: b91: Reduce minimum suspend timeout

### DIFF
--- a/.github/workflows/telink-build.yaml
+++ b/.github/workflows/telink-build.yaml
@@ -107,7 +107,7 @@ jobs:
     - name: Build net/sockets/echo_client for OpenThread with PM deep-sleep
       run: |
         cd ..
-        west build -b tlsr9518adk80d_retention   -d build_ot_echo_client_pm_deep    zephyr/samples/net/sockets/echo_client                   -- -DOVERLAY_CONFIG=overlay-ot-sed.conf -DCONFIG_OPENTHREAD_NETWORKKEY=\"09:24:01:56:04:4a:45:0b:23:22:1e:0e:3b:0d:0e:61:2f:1b:2c:24\" -DCONFIG_PM=y -DCONFIG_BOARD_TLSR9518ADK80D_NON_RETENTION_RAM_CODE=y
+        west build -b tlsr9518adk80d_retention   -d build_ot_echo_client_pm_deep    zephyr/samples/net/sockets/echo_client                   -- -DOVERLAY_CONFIG=overlay-ot-sed.conf -DCONFIG_OPENTHREAD_NETWORKKEY=\"09:24:01:56:04:4a:45:0b:23:22:1e:0e:3b:0d:0e:61:2f:1b:2c:24\" -DCONFIG_PM=y -DCONFIG_BOARD_TLSR9518ADK80D_NON_RETENTION_RAM_CODE=y -DCONFIG_TELINK_B91_2_WIRE_SPI_ENABLE=y
 
     - name: Collect artifacts
       run: |

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -31,8 +31,8 @@
 		state0: state0 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			min-residency-us = <3000>;
-			exit-latency-us = <1000>;
+			min-residency-us = <500>;
+			exit-latency-us = <10>;
 		};
 	};
 

--- a/soc/riscv/riscv-privilege/telink_b91/power.c
+++ b/soc/riscv/riscv-privilege/telink_b91/power.c
@@ -27,7 +27,6 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #else
 #define SYSTICKS_MAX_SLEEP 0xe0000000
 #endif /* CONFIG_BT */
-#define SYSTICKS_MIN_SLEEP 18352
 
 /**
  * @brief This define converts Machine Timer ticks to B91 System Timer ticks.
@@ -106,34 +105,26 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		if (stimer_sleep_ticks < SYSTICKS_MIN_SLEEP) {
-			k_cpu_idle();
-		} else {
-			if (stimer_sleep_ticks > SYSTICKS_MAX_SLEEP) {
-				stimer_sleep_ticks = SYSTICKS_MAX_SLEEP;
-			}
-			if (b91_suspend(tl_sleep_tick + stimer_sleep_ticks)) {
-				current_time +=
-					systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
-				set_mtime(current_time);
-			}
+		if (stimer_sleep_ticks > SYSTICKS_MAX_SLEEP) {
+			stimer_sleep_ticks = SYSTICKS_MAX_SLEEP;
+		}
+		if (b91_suspend(tl_sleep_tick + stimer_sleep_ticks)) {
+			current_time +=
+				systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
+			set_mtime(current_time);
 		}
 		break;
 #ifdef CONFIG_BOARD_TLSR9518ADK80D_RETENTION
 	case PM_STATE_STANDBY:
-		if (stimer_sleep_ticks < SYSTICKS_MIN_SLEEP) {
-			k_cpu_idle();
-		} else {
-			if (stimer_sleep_ticks > SYSTICKS_MAX_SLEEP) {
-				stimer_sleep_ticks = SYSTICKS_MAX_SLEEP;
-			}
-			if (b91_deep_sleep(tl_sleep_tick + stimer_sleep_ticks)) {
-				current_time +=
-					systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
-				set_mtime_compare(wakeup_time);
-				set_mtime(current_time);
-				b91_deep_sleep_retention = true;
-			}
+		if (stimer_sleep_ticks > SYSTICKS_MAX_SLEEP) {
+			stimer_sleep_ticks = SYSTICKS_MAX_SLEEP;
+		}
+		if (b91_deep_sleep(tl_sleep_tick + stimer_sleep_ticks)) {
+			current_time +=
+				systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
+			set_mtime_compare(wakeup_time);
+			set_mtime(current_time);
+			b91_deep_sleep_retention = true;
 		}
 		break;
 #endif /* CONFIG_BOARD_TLSR9518ADK80D_RETENTION */


### PR DESCRIPTION
Zephyr v3.x has scheduler modifications compare to Zephyr v2.x. Now it's possible to keep absolute delay less than 3 system ticks. In that case it's possible to enter suspend mode more often.