### PR TITLE
soc: riscv: b9x: Introduced B92 WFI fix

### DIFF
--- a/soc/riscv/riscv-privilege/common/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/common/CMakeLists.txt
@@ -2,9 +2,17 @@
 
 zephyr_include_directories(.)
 
+#commented out common idle.c file because of need to use the telink idle file
+#the telink B92 CPU contains a WFI bug which causes unexpected behavior on peripheral
 zephyr_sources(
-  idle.c
+  #idle.c
   soc_irq.S
   soc_common_irq.c
   vector.S
   )
+
+if(!CONFIG_SOC_RISCV_TELINK_B92)
+zephyr_sources(
+	idle.c
+)
+endif()

--- a/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
@@ -16,6 +16,12 @@ zephyr_sources(
 	halt.c
 )
 
+if(CONFIG_SOC_RISCV_TELINK_B92)
+zephyr_sources(
+	idle.c
+)
+endif()
+
 zephyr_sources_ifdef(CONFIG_PM
 	power.c
 )

--- a/soc/riscv/riscv-privilege/telink_b9x/idle.c
+++ b/soc/riscv/riscv-privilege/telink_b9x/idle.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017 Jean-Paul Etienne <fractalclone@gmail.com>
+ * Contributors: 2018 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/irq.h>
+#include <zephyr/arch/cpu.h>
+
+#include <zephyr/tracing/tracing.h>
+
+static volatile bool __irq_pending;
+
+static ALWAYS_INLINE void riscv_idle(unsigned int key)
+{
+	sys_trace_idle();
+
+__irq_pending = true;
+
+	/* unlock interrupts */
+	irq_unlock(key);
+
+	/* Due to silicon bug in B92 platform, the WFI emulation is implemented */
+	while (__irq_pending) {
+	}
+}
+
+/**
+ * @brief Power save idle routine
+ *
+ * This function will be called by the kernel idle loop or possibly within
+ * an implementation of _pm_save_idle in the kernel when the
+ * '_pm_save_flag' variable is non-zero.
+ */
+void arch_cpu_idle(void)
+{
+	riscv_idle(MSTATUS_IEN);
+}
+
+/**
+ * @brief Atomically re-enable interrupts and enter low power mode
+ *
+ * INTERNAL
+ * The requirements for arch_cpu_atomic_idle() are as follows:
+ * 1) The enablement of interrupts and entering a low-power mode needs to be
+ *    atomic, i.e. there should be no period of time where interrupts are
+ *    enabled before the processor enters a low-power mode.  See the comments
+ *    in k_lifo_get(), for example, of the race condition that
+ *    occurs if this requirement is not met.
+ *
+ * 2) After waking up from the low-power mode, the interrupt lockout state
+ *    must be restored as indicated in the 'imask' input parameter.
+ */
+void arch_cpu_atomic_idle(unsigned int key)
+{
+	riscv_idle(key);
+}
+
+#ifdef CONFIG_SOC_RISCV_TELINK_B92
+/**
+ * @brief Telink B92 SOC handle IRQ implementation
+ *
+ * - __soc_handle_irq: handle SoC-specific details for a pending IRQ
+ *   (e.g. clear a pending bit in a SoC-specific register)
+ */
+void __soc_handle_irq(unsigned long mcause)
+{
+	__irq_pending = false;
+	__asm__ ("li t1, 1");
+	__asm__ ("sll t0, t1, a0");
+	__asm__ ("csrrc t1, mip, t0");
+}
+#endif


### PR DESCRIPTION
Due to silicon bug in B92 platform, the software WFI mode is implemented