### PR TITLE
boards: tlsr9518adk80d: Support USB DFU by mcuboot

### DIFF
--- a/.github/workflows/telink-build.yaml
+++ b/.github/workflows/telink-build.yaml
@@ -82,7 +82,7 @@ jobs:
     - name: Build bootloader/mcuboot/boot
       run: |
         cd ..
-        west build -b tlsr9518adk80d             -d build_mcuboot                   bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_LOG_DEFAULT_LEVEL=4
+        west build -b tlsr9518adk80d             -d build_mcuboot                   bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_LOG_DEFAULT_LEVEL=3
 
     - name: Build subsys/mgmt/mcumgr/smp_svr for Bluetooth
       run: |
@@ -109,6 +109,16 @@ jobs:
         cd ..
         west build -b tlsr9518adk80d_retention   -d build_ot_echo_client_pm_deep    zephyr/samples/net/sockets/echo_client                   -- -DOVERLAY_CONFIG=overlay-ot-sed.conf -DCONFIG_OPENTHREAD_NETWORKKEY=\"09:24:01:56:04:4a:45:0b:23:22:1e:0e:3b:0d:0e:61:2f:1b:2c:24\" -DCONFIG_PM=y -DCONFIG_BOARD_TLSR9518ADK80D_NON_RETENTION_RAM_CODE=y -DCONFIG_TELINK_B91_2_WIRE_SPI_ENABLE=y
 
+    - name: Build bootloader/mcuboot/boot for USB DFU
+      run: |
+        cd ..
+        west build -b tlsr9518adk80d             -d build_mcuboot_usb_dfu           bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_LOG_DEFAULT_LEVEL=3 -DCONFIG_USB_DFU_WILL_DETACH=n -DCONFIG_BOOT_USB_DFU_GPIO=y -DCONFIG_MCUBOOT_INDICATION_LED=y
+
+    - name: Build basic/blinky for USB DFU
+      run: |
+        cd ..
+        west build -b tlsr9518adk80d             -d build_blinky_usb_dfu            zephyr/samples/basic/blinky                              -- -DCONFIG_BOOTLOADER_MCUBOOT=y
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
@@ -126,6 +136,8 @@ jobs:
         cp ../build_ot_coprocessor_rcp_usb/zephyr/zephyr.bin    telink_build_artifacts/ot_coprocessor_rcp_usb.bin
         cp ../build_retention_basic/zephyr/zephyr.bin           telink_build_artifacts/retention_basic.bin
         cp ../build_ot_echo_client_pm_deep/zephyr/zephyr.bin    telink_build_artifacts/ot_echo_client_pm_retention.bin
+        cp ../build_mcuboot_usb_dfu/zephyr/zephyr.bin           telink_build_artifacts/mcuboot_usb_dfu.bin
+        cp ../build_blinky_usb_dfu/zephyr/zephyr.signed.bin     telink_build_artifacts/blinky_usb_dfu.signed.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v3

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi
@@ -22,6 +22,8 @@
 		pwm-led0 = &pwm_led_blue;
 		pwm-0 = &pwm0;
 		watchdog0 = &wdt;
+		mcuboot-button0 = &key_dfu;
+		mcuboot-led0 = &led_blue;
 	};
 
 	leds {
@@ -67,6 +69,10 @@
 			label = "User KEY3";
 			gpios = <&gpioc 0 GPIO_PULL_DOWN>;
 		};
+		key_dfu: button_dfu {
+			label = "USB DFU";
+			gpios = <&gpiob 0 GPIO_PULL_DOWN>;
+		};
 	};
 
 	chosen {
@@ -103,15 +109,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x18000>;
+			reg = <0x00000000 0x20000>;
 		};
-		slot0_partition: partition@18000 {
+		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x18000 0x6C000>;
+			reg = <0x20000 0x68000>;
 		};
-		slot1_partition: partition@84000 {
+		slot1_partition: partition@88000 {
 			label = "image-1";
-			reg = <0x84000 0x6C000>;
+			reg = <0x88000 0x68000>;
 		};
 		scratch_partition: partition@f0000 {
 			label = "image-scratch";


### PR DESCRIPTION
- MCU boot FW with support USB DFU mode requires ~100KB so boot partition is extended to 128KB.
- Added DFU mode key (PB0) and LED (PB4 - blue). To perform DFU process:
dfu-util --alt <slot number (0 or 1)> --download <signed binary file>