### PR TITLE
drivers: watchdog: telink: watchdog driver for B9x-series

### DIFF
--- a/boards/riscv/tlsr9528a/tlsr9528a.dts
+++ b/boards/riscv/tlsr9528a/tlsr9528a.dts
@@ -23,6 +23,7 @@
 		sw2 = &key_3;
 		pwm-led0 = &pwm_led_blue;
 		pwm-0 = &pwm0;
+		watchdog0 = &wdt;
 	};
 
 	leds {
@@ -201,5 +202,9 @@
 
 zephyr_udc0: &usbd {
 	compatible = "telink,b9x-usbd";
+	status = "okay";
+};
+
+&wdt {
 	status = "okay";
 };

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -32,6 +32,7 @@ zephyr_library_sources_ifdef(CONFIG_WDT_COUNTER wdt_counter.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_NXP_S32 wdt_nxp_s32.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_SMARTBOND wdt_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_TI_TPS382X wdt_ti_tps382x.c)
+zephyr_library_sources_ifdef(CONFIG_WDT_TELINK_B9X wdt_b9x.c)
 
 zephyr_library_sources_ifdef(CONFIG_WDT_DW wdt_dw.c wdt_dw_common.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_INTEL_ADSP wdt_intel_adsp.c wdt_dw_common.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -104,4 +104,6 @@ source "drivers/watchdog/Kconfig.ti_tps382x"
 
 source "drivers/watchdog/Kconfig.tco"
 
+source "drivers/watchdog/Kconfig.b9x"
+
 endif # WATCHDOG

--- a/drivers/watchdog/Kconfig.b9x
+++ b/drivers/watchdog/Kconfig.b9x
@@ -1,0 +1,10 @@
+# Copyright (c) 2023 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Telink B9X WDT configuration options
+config WDT_TELINK_B9X
+	bool "Telink B9X series Watchdog (WDT) Driver"
+	default y
+	depends on DT_HAS_TELINK_B9X_WATCHDOG_ENABLED
+	help
+	  Enable WDT driver for Telink B9X-series MCUs.

--- a/drivers/watchdog/wdt_b9x.c
+++ b/drivers/watchdog/wdt_b9x.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT telink_b9x_watchdog
+
+#include <clock.h>
+#include <watchdog.h>
+#include <zephyr/drivers/watchdog.h>
+
+#define LOG_MODULE_NAME watchdog_b9x
+#if defined(CONFIG_WDT_LOG_LEVEL)
+#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
+#else
+#define LOG_LEVEL LOG_LEVEL_NONE
+#endif
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+
+static int wdt_b9x_setup(const struct device *dev, uint8_t options)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(options);
+
+	wd_start();
+
+	LOG_INF("HW watchdog started");
+
+	return 0;
+}
+
+static int wdt_b9x_disable(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	wd_stop();
+
+	LOG_INF("HW watchdog stopped");
+
+	return 0;
+}
+
+static int wdt_b9x_install_timeout(const struct device *dev,
+				    const struct wdt_timeout_cfg *cfg)
+{
+	ARG_UNUSED(dev);
+
+	if (cfg->window.min != 0) {
+		LOG_WRN("Window watchdog not supported");
+		return -EINVAL;
+	}
+
+	const uint32_t max_timeout_ms = UINT32_MAX / (sys_clk.pclk * 1000);
+
+	if (cfg->window.max > max_timeout_ms) {
+		LOG_WRN("Timeout overflows %umS max is %umS", cfg->window.max, max_timeout_ms);
+		return -EINVAL;
+	}
+
+	if (cfg->flags != WDT_FLAG_RESET_SOC) {
+		LOG_WRN("Not supported flag");
+		return -EINVAL;
+	}
+
+	wd_set_interval_ms(cfg->window.max);
+
+	/* HW restriction */
+	LOG_INF("HW watchdog set to %u mS", cfg->window.max & 0xffffff00);
+
+	return 0;
+}
+
+static int wdt_b9x_feed(const struct device *dev, int channel_id)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(channel_id);
+
+	wd_clear_cnt();
+	return 0;
+}
+
+
+static const struct wdt_driver_api wdt_b9x_api = {
+	.setup = wdt_b9x_setup,
+	.disable = wdt_b9x_disable,
+	.install_timeout = wdt_b9x_install_timeout,
+	.feed = wdt_b9x_feed,
+};
+
+
+static int wdt_b9x_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+
+DEVICE_DT_INST_DEFINE(0, wdt_b9x_init, NULL,
+	NULL, NULL, PRE_KERNEL_1,
+	CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_b9x_api);

--- a/dts/bindings/watchdog/telink,b9x-watchdog.yaml
+++ b/dts/bindings/watchdog/telink,b9x-watchdog.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2023, Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+description: Telink B9X watchdog node
+
+compatible: "telink,b9x-watchdog"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/riscv/telink/telink_b92.dtsi
+++ b/dts/riscv/telink/telink_b92.dtsi
@@ -250,5 +250,11 @@
 						"pull_up_en";
 			status = "okay";
 		};
+
+		wdt: watchdog@140140 {
+			compatible = "telink,b9x-watchdog";
+			reg = <0x140140 0x10>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
Added watchdog basic functionality.
Signed-off-by: Dmytro Huz <diman1436@gmail.com>