### PR TITLE
drivers: bluetooth: hci_b9x: Fixed samples compilation

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi
@@ -18,7 +18,9 @@
 		led2 = &led_white;
 		led3 = &led_red;
 		sw0 = &key_1;
+		sw1 = &key_2;
 		sw2 = &key_3;
+		sw3 = &key_4;
 		pwm-led0 = &pwm_led_blue;
 		pwm-0 = &pwm0;
 		watchdog0 = &wdt;
@@ -63,11 +65,19 @@
 		compatible = "gpio-keys";
 		key_1: button_1 {
 			label = "User KEY1";
-			gpios = <&gpioc 2 GPIO_PULL_DOWN>;
+			gpios = <&gpioc 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+		key_2: button_2 {
+			label = "User KEY2";
+			gpios = <&gpioc 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
 		key_3: button_3 {
 			label = "User KEY3";
-			gpios = <&gpioc 0 GPIO_PULL_DOWN>;
+			gpios = <&gpioc 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+		key_4: button_4 {
+			label = "User KEY4";
+			gpios = <&gpioc 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
 		key_dfu: button_dfu {
 			label = "USB DFU";

--- a/boards/riscv/tlsr9528a/tlsr9528a-common.dtsi
+++ b/boards/riscv/tlsr9528a/tlsr9528a-common.dtsi
@@ -20,7 +20,9 @@
 		led2 = &led_white;
 		led3 = &led_red;
 		sw0 = &key_1;
+		sw1 = &key_2;
 		sw2 = &key_3;
+		sw3 = &key_4;
 		pwm-led0 = &pwm_led_blue;
 		pwm-0 = &pwm0;
 		watchdog0 = &wdt;
@@ -65,11 +67,19 @@
 		compatible = "gpio-keys";
 		key_1: button_1 {
 			label = "User KEY1";
-			gpios = <&gpiod 2 GPIO_PULL_DOWN>;
+			gpios = <&gpiod 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+		key_2: button_2 {
+			label = "User KEY2";
+			gpios = <&gpiod 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
 		key_3: button_3 {
 			label = "User KEY3";
-			gpios = <&gpiod 6 GPIO_PULL_DOWN>;
+			gpios = <&gpiod 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+		key_4: button_4 {
+			label = "User KEY4";
+			gpios = <&gpiof 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
 		key_dfu: button_dfu {
 			label = "USB DFU";

--- a/drivers/bluetooth/hci/hci_b9x.c
+++ b/drivers/bluetooth/hci/hci_b9x.c
@@ -237,7 +237,9 @@ static int hci_b9x_open(void)
 
 static int hci_b9x_close(void)
 {
+#if defined(CONFIG_BT_HCI_HOST) && defined(CONFIG_BT_BROADCASTER)
 	bt_le_adv_stop();
+#endif /* CONFIG_BT_HCI_HOST && CONFIG_BT_BROADCASTER */
 	b9x_bt_controller_deinit();
 
 	return 0;


### PR DESCRIPTION
If CONFIG_BT_BROADCASTER is not set all functionality relative to advertisement is inaccessible so in that case function hci_b9x_close() should avoid call bt_le_adv_stop()