### PR TITLE
Update B92 BLE stack to the V4.0.2.0(ER) version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: fe011c4f2fff47a7d3de7a112a101e691b4dac27
+      revision: ee363b2e82f2c06be7152530c3287b14522ea3b9
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
http://192.168.48.49:8080/browse/ZEPHYR-400