### PR TITLE
soc: riscv: telink_b9x: Add malloc() failed hook

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_sources(
 	soc_irq.S
 	soc.c
 	halt.c
+	sys_heap_alloc_wrap.c
 )
 
 if(CONFIG_SOC_RISCV_TELINK_B92)
@@ -34,3 +35,10 @@ zephyr_compile_options_ifdef(CONFIG_TELINK_B9x_HWDSP -mext-dsp)
 zephyr_compile_options_ifndef(CONFIG_RISCV_GP -mno-relax)
 zephyr_linker_sources(ROM_START SORT_KEY 0x0 init.ld)
 zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0 ilm.ld)
+
+# Wrap allocator functions
+zephyr_link_libraries(
+	-Wl,--wrap,sys_heap_alloc
+	-Wl,--wrap,sys_heap_aligned_alloc
+	-Wl,--wrap,sys_heap_aligned_realloc
+)

--- a/soc/riscv/riscv-privilege/telink_b9x/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b9x/Kconfig.soc
@@ -86,3 +86,10 @@ config TELINK_B9X_2_WIRE_SPI_ENABLE
 	default n
 	help
 		This option enables 2-wire SPI interface to FLASH
+
+config TELINK_B9X_MALLOC_FAILED_HOOK
+	bool "Stop SW execution when system heap allocation failed"
+	depends on SOC_SERIES_RISCV_TELINK_B9X
+	default y
+	help
+		This option stops SW execution when system heap allocation failed.

--- a/soc/riscv/riscv-privilege/telink_b9x/sys_heap_alloc_wrap.c
+++ b/soc/riscv/riscv-privilege/telink_b9x/sys_heap_alloc_wrap.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_heap.h>
+#include <stdlib.h>
+
+#ifdef CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK
+static void sys_heap_alloc_failed(const char *function, const struct sys_heap *heap, size_t bytes)
+{
+	(void)heap;
+
+	printk("!!! %s failed, with size %u\n", function, bytes);
+	abort();
+}
+#endif /* CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK */
+
+void *__wrap_sys_heap_alloc(struct sys_heap *heap, size_t bytes)
+{
+	extern void *__real_sys_heap_alloc(struct sys_heap *heap, size_t bytes);
+	void *result = __real_sys_heap_alloc(heap, bytes);
+#ifdef CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK
+	if (!result) {
+		sys_heap_alloc_failed("sys_heap_alloc()", heap, bytes);
+	}
+#endif /* CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK */
+	return result;
+}
+
+void *__wrap_sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
+{
+	extern void *__real_sys_heap_aligned_alloc(
+		struct sys_heap *heap, size_t align, size_t bytes);
+	void *result = __real_sys_heap_aligned_alloc(heap, align, bytes);
+#ifdef CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK
+	if (!result) {
+		sys_heap_alloc_failed("sys_heap_aligned_alloc()", heap, bytes);
+	}
+#endif /* CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK */
+	return result;
+}
+
+void *__wrap_sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr, size_t align, size_t bytes)
+{
+	extern void *__real_sys_heap_aligned_realloc(
+		struct sys_heap *heap, void *ptr, size_t align, size_t bytes);
+	void *result = __real_sys_heap_aligned_realloc(heap, ptr, align, bytes);
+#ifdef CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK
+	if (!result) {
+		sys_heap_alloc_failed("sys_heap_aligned_realloc()", heap, bytes);
+	}
+#endif /* CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK */
+	return result;
+}


### PR DESCRIPTION
Add checker for heap allocation functions (also c++ operator new). Checker generates abort() in case of failed allocation (NULL). The feature is controlled by CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK boolean option which is enabled by default.