### PR TITLE
soc: riscv: telink_b9x: Print heap info during fail

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b9x/sys_heap_alloc_wrap.c
+++ b/soc/riscv/riscv-privilege/telink_b9x/sys_heap_alloc_wrap.c
@@ -9,11 +9,11 @@
 #include <stdlib.h>
 
 #ifdef CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK
-static void sys_heap_alloc_failed(const char *function, const struct sys_heap *heap, size_t bytes)
+static void sys_heap_alloc_failed(const char *function, struct sys_heap *heap, size_t bytes)
 {
-	(void)heap;
-
 	printk("!!! %s failed, with size %u\n", function, bytes);
+	sys_heap_print_info(heap, false);
+
 	abort();
 }
 #endif /* CONFIG_TELINK_B9X_MALLOC_FAILED_HOOK */


### PR DESCRIPTION
On platform there are two heaps which are configured by:
CONFIG_HEAP_MEM_POOL_SIZE (kernel objects)
CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE (applications allocators)
printing information provides a possibility to distinguish which heap overflows.