### PR TITLE
boards: riscv: telink: Documentation update

### DIFF
--- a/boards/riscv/tlsr9518adk80d/board.cmake
+++ b/boards/riscv/tlsr9518adk80d/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(spi_burn)
-include(${ZEPHYR_BASE}/boards/common/spi_burn.board.cmake)
+board_runner_args(bdt_tool)
+include(${ZEPHYR_BASE}/boards/common/bdt_tool.board.cmake)

--- a/boards/riscv/tlsr9518adk80d/doc/index.rst
+++ b/boards/riscv/tlsr9518adk80d/doc/index.rst
@@ -22,9 +22,10 @@ Hardware
 ********
 
 The TLSR9518A SoC integrates a powerful 32-bit RISC-V MCU, DSP, AI Engine, 2.4 GHz ISM Radio, 256
-KB SRAM (128 KB of Data Local Memory and 128 KB of Instruction Local Memory), external Flash memory,
-stereo audio codec, 14 bit AUX ADC, analog and digital Microphone input, PWM, flexible IO interfaces,
-and other peripheral blocks required for advanced IoT, hearable, and wearable devices.
+KB SRAM (128 KB of Data Local Memory and 128 KB of Instruction Local Memory first 64 KB of this memory
+supports retention feature), external Flash memory, stereo audio codec, 14 bit AUX ADC,
+analog and digital Microphone input, PWM, flexible IO interfaces, and other peripheral blocks required
+for advanced IoT, hearable, and wearable devices.
 
 .. figure:: img/tlsr9518_block_diagram.jpg
      :align: center
@@ -33,7 +34,7 @@ and other peripheral blocks required for advanced IoT, hearable, and wearable de
 The TLSR9518ADK80D default board configuration provides the following hardware components:
 
 - RF conducted antenna
-- 1 MB External Flash memory with reset button
+- 1 MB External SPI Flash memory with reset button. (Possible to mount 1/2/4 MB)
 - Chip reset button
 - Mini USB interface
 - 4-wire JTAG
@@ -76,22 +77,32 @@ The Zephyr TLSR9518ADK80D board configuration supports the following hardware fe
 +----------------+------------+------------------------------+
 | ADC            | on-chip    | adc                          |
 +----------------+------------+------------------------------+
+| USB (device)   | on-chip    | usb_dc                       |
++----------------+------------+------------------------------+
+| AES            | on-chip    | mbedtls                      |
++----------------+------------+------------------------------+
+| PKE            | on-chip    | mbedtls                      |
++----------------+------------+------------------------------+
+
+Board supports power-down modes: suspend and deep-sleep. For deep-sleep mode only 64KB of retention memory is available.
+Board supports HW cryptography acceleration (AES and ECC till 256 bits). MbedTLS interface is used as cryptography front-end.
 
 .. note::
-   To support "button" example project PC3-KEY3 (J20-19, J20-20) jumper needs to be removed and KEY3 (J20-19) should be connected to VDD3_DCDC (J51-13) externally.
+   To support "button" example project PC3-KEY3 (J20-19, J20-20) jumper needs to be removed and KEY3 (J20-19) should be connected to GND (J50-23) externally.
 
    For the rest example projects use the default jumpers configuration.
-
-Other hardware features and example projects are not supported yet.
 
 Limitations
 -----------
 
-- Maximum 3 GPIO pins could be configured to generate interrupts simultaneously. All pins must be related to different ports and use different IRQ numbers.
+- Maximum 3 GPIO ports could be configured to generate external interrupts simultaneously. All ports should use different IRQ numbers.
 - DMA mode is not supported by I2C, SPI and Serial Port.
-- UART hardware flow control is not implemented.
 - SPI Slave mode is not implemented.
 - I2C Slave mode is not implemented.
+- Bluetooth is not compatible with deep-sleep mode. Only suspend is allowed when Bluetooth is active.
+- USB working only in active mode (No power down supported).
+- During deep-sleep all GPIO's are in Hi-Z mode.
+- Shell is not compatible with sleep modes.
 
 Default configuration and IOs
 =============================
@@ -102,13 +113,13 @@ System Clock
 The TLSR9518ADK80D board is configured to use the 24 MHz external crystal oscillator
 with the on-chip PLL/DIV generating the 48 MHz system clock.
 The following values also could be assigned to the system clock in the board DTS file
-(``boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts``):
+(``boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi``):
 
 - 16000000
 - 24000000
 - 32000000
 - 48000000
-- 64000000
+- 60000000
 - 96000000
 
 .. code-block::
@@ -127,7 +138,7 @@ currently enabled (PORT_B for LEDs control and PORT_C for buttons) in the board 
 - Key Matrix SW0: PC2_PC3, SW1: PC2_PC1, SW2: PC0_PC3, SW3: PC0_PC1
 
 Peripheral's pins on the SoC are mapped to the following GPIO pins in the
-``boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts`` file:
+``boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi`` file:
 
 - UART0 TX: PB2, RX: PB3
 - UART1 TX: PC6, RX: PC7
@@ -161,21 +172,6 @@ Here is an example for the "hello_world" application.
    # From the root of the zephyr repository
    west build -b tlsr9518adk80d samples/hello_world
 
-To use `Telink RISC-V Linux Toolchain`_, ``ZEPHYR_TOOLCHAIN_VARIANT`` and ``CROSS_COMPILE`` variables need to be set.
-In addition ``CONFIG_FPU=y`` must be selected in ``boards/riscv/tlsr9518adk80d/tlsr9518adk80d_defconfig`` file since this
-toolchain is compatible only with the float point unit usage.
-
-.. code-block:: console
-
-   # Set Zephyr toolchain variant to cross-compile
-   export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-   # Specify the Telink RISC-V Toolchain location
-   export CROSS_COMPILE=~/toolchains/nds32le-elf-mculib-v5f/bin/riscv32-elf-
-   # From the root of the zephyr repository
-   west build -b tlsr9518adk80d samples/hello_world
-
-`Telink RISC-V Linux Toolchain`_ is available on the `Burning and Debugging Tools for TLSR9 Series in Linux`_ page.
-
 Open a serial terminal with the following settings:
 
 - Speed: 115200
@@ -195,74 +191,33 @@ serial port:
 Flashing
 ========
 
-To flash the TLSR9518ADK80D board see the sources below:
+To flash the TLSR9528A board see the sources below:
 
 - `Burning and Debugging Tools for all Series`_
-- `Burning and Debugging Tools for TLSR9 Series`_
-- `Burning and Debugging Tools for TLSR9 Series in Linux`_
 
-It is also possible to use the west flash command, but additional steps are required to set it up:
+It is also possible to use the west flash command. Download BDT tool for Linux `Burning and Debugging Tools for Linux`_ or
+`Burning and Debugging Tools for Windows`_ and extract archive into some directory you wish TELINK_BDT_BASE_DIR
 
-- Download `Telink RISC-V Linux Toolchain`_. The toolchain contains tools for the board flashing as well.
-- Since the ICEman tool is created for the 32-bit OS version it is necessary to install additional packages in case of the 64-bit OS version.
+- Now you should be able to run the west flash command with the BDT path specified (TELINK_BDT_BASE_DIR).
 
 .. code-block:: console
 
-   sudo dpkg --add-architecture i386
-   sudo apt-get update
-   sudo apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386
+   west flash --bdt-path=$TELINK_BDT_BASE_DIR --erase
 
--  Run the "ICEman.sh" script.
+- You can also run the west flash command without BDT path specification if TELINK_BDT_BASE_DIR is in your environment (.bashrc).
 
 .. code-block:: console
 
-   # From the root of the {path to the Telink RISC-V Linux Toolchain}/ice repository
-   sudo ./ICEman.sh
-
-- Now you should be able to run the west flash command with the toolchain path specified (TELINK_TOOLCHAIN_PATH).
-
-.. code-block:: console
-
-   west flash --telink-tools-path=$TELINK_TOOLCHAIN_PATH
-
-- You can also run the west flash command without toolchain path specification if add SPI_burn and ICEman to PATH.
-
-.. code-block:: console
-
-    export PATH=$TELINK_TOOLCHAIN_PATH/flash/bin:"$PATH"
-    export PATH=$TELINK_TOOLCHAIN_PATH/ice:"$PATH"
-
-Debugging
-=========
-
-This port supports UART debug and OpenOCD+GDB. The `west debug` command also supported. You may run
-it in a simple way, like:
-
-.. code-block:: console
-
-   west debug
-
-Or with additional arguments, like:
-
-.. code-block:: console
-
-   west debug --gdb-port=<port_number> --gdb-ex=<additional_ex_arguments>
-
-Example:
-
-.. code-block:: console
-
-   west debug --gdb-port=1111 --gdb-ex="-ex monitor reset halt -ex b main -ex continue"
+   export TELINK_BDT_BASE_DIR="/opt/telink_bdt/"
 
 References
 **********
 
 .. target-notes::
 
-.. _Telink TLSR9 series chipset: http://wiki.telink-semi.cn/wiki/chip-series/TLSR9-Series/
-.. _Telink B91 Generic Starter Kit Hardware Guide: http://wiki.telink-semi.cn/wiki/Hardware/B91_Generic_Starter_Kit_Hardware_Guide/
-.. _Telink RISC-V Linux Toolchain: http://wiki.telink-semi.cn/tools_and_sdk/Tools/IDE/telink_riscv_linux_toolchain.zip
-.. _Burning and Debugging Tools for all Series: http://wiki.telink-semi.cn/wiki/IDE-and-Tools/Burning-and-Debugging-Tools-for-all-Series/
-.. _Burning and Debugging Tools for TLSR9 Series: http://wiki.telink-semi.cn/wiki/IDE-and-Tools/Burning-and-Debugging-Tools-for-TLSR9-Series/
-.. _Burning and Debugging Tools for TLSR9 Series in Linux: http://wiki.telink-semi.cn/wiki/IDE-and-Tools/BDT_for_TLSR9_Series_in_Linux/
+.. _Telink TLSR9 series chipset: https://wiki.telink-semi.cn/wiki/chip-series/TLSR951x-Series/
+.. _Telink B91 Generic Starter Kit Hardware Guide: https://wiki.telink-semi.cn/wiki/Hardware/B91_Generic_Starter_Kit_Hardware_Guide/
+.. _Burning and Debugging Tools for all Series: https://wiki.telink-semi.cn/wiki/IDE-and-Tools/Burning-and-Debugging-Tools-for-all-Series/
+.. _Burning and Debugging Tools for Linux: https://wiki.telink-semi.cn/tools_and_sdk/Tools/BDT/Telink_Libusb_BDT-Linux-X64-1.5.2.1.tar
+.. _Burning and Debugging Tools for Windows: https://wiki.telink-semi.cn/tools_and_sdk/Tools/BDT/BDT.zip
 .. _Zephyr Getting Started Guide: https://docs.zephyrproject.org/latest/getting_started/index.html

--- a/boards/riscv/tlsr9528a/doc/index.rst
+++ b/boards/riscv/tlsr9528a/doc/index.rst
@@ -22,9 +22,10 @@ Hardware
 ********
 
 The TLSR9528A SoC integrates a powerful 32-bit RISC-V MCU, DSP, 2.4 GHz ISM Radio, 512
-KB SRAM (256 KB of Data Local Memory and 256 KB of Instruction Local Memory), external Flash memory,
-stereo audio codec, 14 bit AUX ADC, analog and digital Microphone input, PWM, flexible IO interfaces,
-and other peripheral blocks required for advanced IoT, hearable, and wearable devices.
+KB SRAM (256 KB of Data Local Memory and 256 KB of Instruction Local Memory first 96 KB of this memory
+supports retention feature), external Flash memory, stereo audio codec, 14 bit AUX ADC,
+analog and digital Microphone input, PWM, flexible IO interfaces, and other peripheral blocks required
+for advanced IoT, hearable, and wearable devices.
 
 .. figure:: img/tlsr9528_block_diagram.jpg
      :align: center
@@ -33,7 +34,7 @@ and other peripheral blocks required for advanced IoT, hearable, and wearable de
 The TLSR9528A default board configuration provides the following hardware components:
 
 - RF conducted antenna
-- 1 MB External Flash memory with reset button
+- 1 MB External SPI Flash memory with reset button. (Possible to mount 1/2/4 MB)
 - Chip reset button
 - Mini USB interface
 - 4-wire JTAG
@@ -76,21 +77,32 @@ The Zephyr TLSR9528A board configuration supports the following hardware feature
 +----------------+------------+------------------------------+
 | ADC            | on-chip    | adc                          |
 +----------------+------------+------------------------------+
+| USB (device)   | on-chip    | usb_dc                       |
++----------------+------------+------------------------------+
+| AES            | on-chip    | mbedtls                      |
++----------------+------------+------------------------------+
+| PKE            | on-chip    | mbedtls                      |
++----------------+------------+------------------------------+
+
+Board supports power-down modes: suspend and deep-sleep. For deep-sleep mode only 96KB of retention memory is available.
+Board supports HW cryptography acceleration (AES and ECC till 256 bits). MbedTLS interface is used as cryptography front-end.
 
 .. note::
    To support "button" example project PD6-KEY3 (J5-13, J5-14) jumper needs to be removed and KEY3 (J5-13) should be connected to GND (J3-30) externally.
 
    For the rest example projects use the default jumpers configuration.
 
-Other hardware features and example projects are not supported yet.
-
 Limitations
 -----------
 
-- Maximum 3 GPIO pins could be configured to generate interrupts simultaneously. All pins must be related to different ports and use different IRQ numbers.
+- Maximum 3 GPIO ports could be configured to generate external interrupts simultaneously. All ports should use different IRQ numbers.
 - DMA mode is not supported by I2C, SPI and Serial Port.
 - SPI Slave mode is not implemented.
 - I2C Slave mode is not implemented.
+- Bluetooth is not compatible with deep-sleep mode. Only suspend is allowed when Bluetooth is active.
+- USB working only in active mode (No power down supported).
+- During deep-sleep all GPIO's are in Hi-Z mode.
+- Shell is not compatible with sleep modes.
 
 Default configuration and IOs
 =============================
@@ -101,13 +113,13 @@ System Clock
 The TLSR9528A board is configured to use the 24 MHz external crystal oscillator
 with the on-chip PLL/DIV generating the 48 MHz system clock.
 The following values also could be assigned to the system clock in the board DTS file
-(``boards/riscv/tlsr9528a/tlsr9528a.dts``):
+(``boards/riscv/tlsr9528a/tlsr9528a-common.dtsi``):
 
 - 16000000
 - 24000000
 - 32000000
 - 48000000
-- 64000000
+- 60000000
 - 96000000
 
 .. code-block::
@@ -126,7 +138,7 @@ currently enabled:
 - Key Matrix SW2: PD2_PD6, SW3: PD2_PF6, SW4: PD7_PD6, SW5: PD7_PF6
 
 Peripheral's pins on the SoC are mapped to the following GPIO pins in the
-``boards/riscv/tlsr9528a/tlsr9528a.dts`` file:
+``boards/riscv/tlsr9528a/tlsr9528a-common.dtsi`` file:
 
 - UART0 TX: PB2, RX: PB3
 - UART1 TX: PC6, RX: PC7
@@ -206,7 +218,7 @@ References
 
 .. _Telink TLSR9 series chipset: [UNDER_DEVELOPMENT]
 .. _Telink B92 Generic Starter Kit Hardware Guide: [UNDER_DEVELOPMENT]
-.. _Burning and Debugging Tools for all Series: http://wiki.telink-semi.cn/wiki/IDE-and-Tools/Burning-and-Debugging-Tools-for-all-Series/
-.. _Burning and Debugging Tools for Linux: http://wiki.telink-semi.cn/tools_and_sdk/Tools/BDT/Telink_Libusb_BDT-Linux-X64-1.5.2.1.tar
-.. _Burning and Debugging Tools for Windows: http://wiki.telink-semi.cn/tools_and_sdk/Tools/BDT/BDT.zip
+.. _Burning and Debugging Tools for all Series: https://wiki.telink-semi.cn/wiki/IDE-and-Tools/Burning-and-Debugging-Tools-for-all-Series/
+.. _Burning and Debugging Tools for Linux: https://wiki.telink-semi.cn/tools_and_sdk/Tools/BDT/Telink_Libusb_BDT-Linux-X64-1.5.2.1.tar
+.. _Burning and Debugging Tools for Windows: https://wiki.telink-semi.cn/tools_and_sdk/Tools/BDT/BDT.zip
 .. _Zephyr Getting Started Guide: https://docs.zephyrproject.org/latest/getting_started/index.html


### PR DESCRIPTION
- Updated B91 and B92 boards documentation
- B91 board by default is using BDT as west flash back-end