### PR TITLE
soc: riscv: riscv-privelege: telink_b9x: Enable wfi emulation for B91…

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
@@ -17,11 +17,9 @@ zephyr_sources(
 	sys_heap_alloc_wrap.c
 )
 
-if(CONFIG_SOC_RISCV_TELINK_B92)
 zephyr_sources(
 	idle.c
 )
-endif()
 
 zephyr_sources_ifdef(CONFIG_PM
 	power.c


### PR DESCRIPTION
… SoC

Enable WFI emulation for B91 SoC to increase RF stability