### PR TITLE
riscv: telink: Reduce power consumption in deep-sleep mode

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_retention.dts
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_retention.dts
@@ -37,7 +37,7 @@
 			compatible = "zephyr,power-state";
 			power-state-name = "standby";
 			min-residency-us = <100000>;
-			exit-latency-us = <7000>;
+			exit-latency-us = <1000>;
 		};
 	};
 };

--- a/boards/riscv/tlsr9528a/tlsr9528a_retention.dts
+++ b/boards/riscv/tlsr9528a/tlsr9528a_retention.dts
@@ -37,7 +37,7 @@
 			compatible = "zephyr,power-state";
 			power-state-name = "standby";
 			min-residency-us = <100000>;
-			exit-latency-us = <7000>;
+			exit-latency-us = <1000>;
 		};
 	};
 };

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -73,7 +73,7 @@
 		power: power@80140180 {
 			compatible = "telink,b91-power";
 			reg = <0x80140180 0x40>;
-			power-mode = "LDO_1P4_LDO_1P8";
+			power-mode = "DCDC_1P4_DCDC_1P8";
 			vbat-type = "VBAT_MAX_VALUE_GREATER_THAN_3V6";
 			status = "okay";
 		};

--- a/dts/riscv/telink/telink_b92.dtsi
+++ b/dts/riscv/telink/telink_b92.dtsi
@@ -73,7 +73,7 @@
 		power: power@80140180 {
 			compatible = "telink,b92-power";
 			reg = <0x80140180 0x40>;
-			power-mode = "LDO_1P4_LDO_2P0";
+			power-mode = "DCDC_1P4_DCDC_2P0";
 			vbat-type = "VBAT_MAX_VALUE_GREATER_THAN_3V6";
 			status = "okay";
 		};


### PR DESCRIPTION
- Use powering from DC/DC instead of LDO
- Reduce deep-sleep exit time to 1mS