### PR TITLE
dts: riscv: telink: Change power mode

### DIFF
--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -73,7 +73,7 @@
 		power: power@80140180 {
 			compatible = "telink,b91-power";
 			reg = <0x80140180 0x40>;
-			power-mode = "DCDC_1P4_DCDC_1P8";
+			power-mode = "DCDC_1P4_LDO_1P8";
 			vbat-type = "VBAT_MAX_VALUE_GREATER_THAN_3V6";
 			status = "okay";
 		};

--- a/dts/riscv/telink/telink_b92.dtsi
+++ b/dts/riscv/telink/telink_b92.dtsi
@@ -73,7 +73,7 @@
 		power: power@80140180 {
 			compatible = "telink,b92-power";
 			reg = <0x80140180 0x40>;
-			power-mode = "DCDC_1P4_DCDC_2P0";
+			power-mode = "DCDC_1P4_LDO_2P0";
 			vbat-type = "VBAT_MAX_VALUE_GREATER_THAN_3V6";
 			status = "okay";
 		};


### PR DESCRIPTION
Set combined power mode DCDC_XX_LDO_XX due to instability observed in B91 chip when use DCDC mode.