### PR TITLE
soc: riscv: telink_w91: ipc: Kconfig.ipc: Set cache line size

### DIFF
--- a/soc/riscv/riscv-privilege/telink_w91/ipc/Kconfig.ipc
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/Kconfig.ipc
@@ -34,3 +34,13 @@ config TELINK_W91_IPC_DISPATCHER_BOUND_TIMEOUT_MS
 	depends on TELINK_W91_IPC_DISPATCHER
 	help
 		This option sets Telink IPC dispatcher bound timeout in mS.
+
+if SPSC_PBUF_CACHE_FLAG || SPSC_PBUF_CACHE_ALWAYS
+
+config SPSC_PBUF_REMOTE_DCACHE_LINE
+	default 32
+
+config DCACHE_LINE_SIZE
+	default 32
+
+endif # SPSC_PBUF_CACHE_FLAG || SPSC_PBUF_CACHE_ALWAYS


### PR DESCRIPTION
Set cache line sizes for D25 and N22 cores.