### PR TITLE
soc: riscv: telink_w91: Add multiple instances to IPC drivers

### DIFF
--- a/.github/workflows/telink-w91-build.yaml
+++ b/.github/workflows/telink-w91-build.yaml
@@ -43,10 +43,16 @@ jobs:
         cd ..
         west build -b tlsr9118bdk40d             -d build_blinky_w91                    zephyr/samples/basic/blinky
 
+    - name: Build W91 basic/button
+      run: |
+        cd ..
+        west build -b tlsr9118bdk40d             -d build_button_w91                    zephyr/samples/basic/button
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
         cp ../build_blinky_w91/zephyr/zephyr.bin                    telink_build_artifacts/w91_blinky.bin
+        cp ../build_button_w91/zephyr/zephyr.bin                    telink_build_artifacts/w91_button.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v3

--- a/boards/riscv/tlsr9118bdk40d/tlsr9118bdk40d-common.dtsi
+++ b/boards/riscv/tlsr9118bdk40d/tlsr9118bdk40d-common.dtsi
@@ -34,7 +34,7 @@
 			label = "LED Green";
 		};
 	};
-	/* Short TL_Key4 (J20 pin 17) to ground */
+	/* Short TL_Key1 (J20 pin 11) to ground (J20 pin 25-35) */
 	keys {
 		compatible = "gpio-keys";
 

--- a/dts/bindings/gpio/telink,w91-gpio.yaml
+++ b/dts/bindings/gpio/telink,w91-gpio.yaml
@@ -11,6 +11,9 @@ properties:
   "#gpio-cells":
     const: 2
 
+  ngpios:
+    required: true
+
 gpio-cells:
   - pin
   - flags

--- a/dts/riscv/telink/telink_w91.dtsi
+++ b/dts/riscv/telink/telink_w91.dtsi
@@ -112,6 +112,7 @@
 			gpio-controller;
 			status = "disabled";
 			#gpio-cells = <2>;
+			ngpios = <25>;
 		};
 	};
 };

--- a/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_sources(
 if(CONFIG_TELINK_W91_IPC_DISPATCHER)
 zephyr_sources(
 	ipc/ipc_dispatcher.c
+	ipc/ipc_based_driver.c
 )
 endif()
 

--- a/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.c
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "ipc_based_driver.h"
+#include <zephyr/logging/log.h>
+
+#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_MODULE_NAME ipc_based_driver
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+void ipc_based_driver_init(struct ipc_based_driver *drv)
+{
+	(void)k_mutex_init(&drv->mutex);
+	(void)k_sem_init(&drv->resp_sem, 0, 1);
+}
+
+int ipc_based_driver_send(struct ipc_based_driver *drv,
+	const void *tx_data, size_t tx_len,
+	struct ipc_based_driver_ctx *ctx, uint32_t timeout_ms)
+{
+	int result = 0;
+
+	struct ipc_based_driver_response_data {
+		struct k_sem *resp_sem;
+		struct ipc_based_driver_ctx *ctx;
+	} response_data = {
+		.resp_sem = &drv->resp_sem,
+		.ctx = ctx,
+	};
+
+void resp_cb(const void *data, size_t len, void *param)
+{
+	struct ipc_based_driver_response_data *response_data =
+		(struct ipc_based_driver_response_data *)param;
+
+	if (response_data->ctx && response_data->ctx->unpack) {
+		response_data->ctx->unpack(response_data->ctx->result, data, len);
+	}
+	k_sem_give(response_data->resp_sem);
+}
+
+	k_mutex_lock(&drv->mutex, K_FOREVER);
+	uint32_t id = *(uint32_t *)tx_data;
+
+	k_sem_reset(&drv->resp_sem);
+	ipc_dispatcher_add(id, resp_cb, &response_data);
+
+	do {
+		if (ipc_dispatcher_send(tx_data, tx_len) != tx_len) {
+			LOG_ERR("IPC data send error (id=%x)", id);
+			result = -ECANCELED;
+			break;
+		}
+
+		if (k_sem_take(&drv->resp_sem, K_MSEC(timeout_ms))) {
+			LOG_ERR("IPC response timeout (id=%x)", id);
+			result = -ETIMEDOUT;
+			break;
+		}
+	} while (0);
+
+	ipc_dispatcher_rm(id);
+	k_mutex_unlock(&drv->mutex);
+
+	return result;
+}

--- a/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IPC_BASED_DRIVER_H
+#define IPC_BASED_DRIVER_H
+
+#include "ipc_dispatcher.h"
+#include <zephyr/kernel.h>
+
+enum ipc_dispatcher_id {
+	IPC_DISPATCHER_SYS                      = 0x0,
+	IPC_DISPATCHER_UART                     = 0x100,
+	IPC_DISPATCHER_GPIO                     = 0x200,
+	IPC_DISPATCHER_PWM                      = 0x300,
+} __attribute__((__packed__));
+
+typedef void (*ipc_based_driver_unpack_t)(void *result, const uint8_t *data, size_t len);
+
+struct ipc_based_driver_ctx {
+	ipc_based_driver_unpack_t unpack;
+	void *result;
+};
+
+struct ipc_based_driver {
+	struct k_mutex mutex;
+	struct k_sem resp_sem;
+};
+
+void ipc_based_driver_init(struct ipc_based_driver *drv);
+int ipc_based_driver_send(struct ipc_based_driver *drv,
+	const void *tx_data, size_t tx_len,
+	struct ipc_based_driver_ctx *ctx, uint32_t timeout_ms);
+
+/* Macros to pack/unpack the different types */
+
+#define IPC_DISPATCHER_PACK_FIELD(buff, field)                                 \
+do {                                                                           \
+	memcpy(buff, &field, sizeof(field));                                       \
+	buff += sizeof(field);                                                     \
+} while (0)
+
+#define IPC_DISPATCHER_UNPACK_FIELD(buff, field)                               \
+do {                                                                           \
+	memcpy(&field, buff, sizeof(field));                                       \
+	buff += sizeof(field);                                                     \
+} while (0)
+
+/* Macros for making ipc dispatcher id */
+
+#define IPC_DISPATCHER_MK_ID(ipc, inst)                                        \
+	(((ipc & 0xffffff) << 8) | (inst & 0xff))
+
+/* Macros for packing data without param (only id) */
+
+#define IPC_DISPATCHER_PACK_FUNC_WITHOUT_PARAM(name, ipc_id)                   \
+static size_t pack_##name(uint8_t inst, void *unpack_data, uint8_t *pack_data) \
+{                                                                              \
+	if (pack_data != NULL) {                                                   \
+		uint32_t id = IPC_DISPATCHER_MK_ID(ipc_id, inst);                      \
+                                                                               \
+		IPC_DISPATCHER_PACK_FIELD(pack_data, id);                              \
+	}                                                                          \
+                                                                               \
+	return sizeof(uint32_t);                                                   \
+}
+
+/* Macros for unpacking data only with error param */
+
+#define IPC_DISPATCHER_UNPACK_FUNC_ONLY_WITH_ERROR_PARAM(name)                 \
+static void unpack_##name(void *unpack_data,                                   \
+		const uint8_t *pack_data, size_t pack_data_len)                        \
+{                                                                              \
+	int *p_err = unpack_data;                                                  \
+	size_t expect_len = sizeof(uint32_t) + sizeof(*p_err);                     \
+                                                                               \
+	if (expect_len != pack_data_len) {                                         \
+		*p_err = -EINVAL;                                                      \
+		return;                                                                \
+	}                                                                          \
+                                                                               \
+	pack_data += sizeof(uint32_t);                                             \
+	IPC_DISPATCHER_UNPACK_FIELD(pack_data, *p_err);                            \
+}
+
+/* Macros for sending data from host device to remote */
+
+#define IPC_DISPATCHER_HOST_SEND_DATA(ipc, inst, name,                         \
+	tx_buff, rx_buff, timeout_ms)                                              \
+do {                                                                           \
+	uint8_t packed_data[pack_##name(inst, NULL, NULL)];                        \
+	size_t packed_len = pack_##name(inst, tx_buff, packed_data);               \
+	struct ipc_based_driver_ctx ctx = {                                        \
+		.unpack = unpack_##name,                                               \
+		.result = rx_buff,                                                     \
+	};                                                                         \
+                                                                               \
+	int ipc_err = ipc_based_driver_send(ipc, packed_data, packed_len,          \
+		&ctx, CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);                 \
+                                                                               \
+	if (ipc_err) {                                                             \
+		return ipc_err;                                                        \
+	}                                                                          \
+} while (0)
+
+#endif /* IPC_BASED_DRIVER_H */

--- a/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_dispatcher.c
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_dispatcher.c
@@ -5,7 +5,6 @@
  */
 #include "ipc_dispatcher.h"
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/ipc/ipc_service.h>
 #include <stdlib.h>
@@ -17,7 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 struct ipc_dispatcher_record {
 	sys_snode_t              node;
-	enum ipc_dispatcher_id   id;
+	uint32_t                 id;
 	ipc_dispatcher_cb_t      callback;
 	void                    *param;
 };
@@ -34,8 +33,8 @@ static void endpoint_bound(void *priv)
 
 static void endpoint_received(const void *data, size_t len, void *priv)
 {
-	if (len >= sizeof(enum ipc_dispatcher_id)) {
-		enum ipc_dispatcher_id *id = (enum ipc_dispatcher_id *)data;
+	if (len >= sizeof(uint32_t)) {
+		uint32_t *id = (uint32_t *)data;
 		bool processed = false;
 		struct ipc_dispatcher_record *record;
 
@@ -87,7 +86,7 @@ static int ipc_dispatcher_start(void)
 	return ret;
 }
 
-void ipc_dispatcher_add(enum ipc_dispatcher_id id, ipc_dispatcher_cb_t cb, void *param)
+void ipc_dispatcher_add(uint32_t id, ipc_dispatcher_cb_t cb, void *param)
 {
 	struct ipc_dispatcher_record *record = malloc(sizeof(struct ipc_dispatcher_record));
 
@@ -120,7 +119,7 @@ void ipc_dispatcher_add(enum ipc_dispatcher_id id, ipc_dispatcher_cb_t cb, void 
 	}
 }
 
-void ipc_dispatcher_rm(enum ipc_dispatcher_id id)
+void ipc_dispatcher_rm(uint32_t id)
 {
 	bool rm_elem = false;
 	struct ipc_dispatcher_record *record;

--- a/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_dispatcher.h
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_dispatcher.h
@@ -7,116 +7,17 @@
 #ifndef IPC_DISPATCHER_H
 #define IPC_DISPATCHER_H
 
-#include <zephyr/kernel.h>
-
+#include <stdint.h>
 #include <stddef.h>
-#include <string.h>
 
 /* Data types */
-
-enum ipc_dispatcher_id {
-	IPC_DISPATCHER_SYS                      = 0x0,
-	IPC_DISPATCHER_UART                     = 0x100,
-	IPC_DISPATCHER_GPIO                     = 0x200,
-	IPC_DISPATCHER_PWM                      = 0x300,
-} __attribute__((__packed__));
 
 typedef void (*ipc_dispatcher_cb_t)(const void *data, size_t len, void *param);
 
 /* Public APIs */
 
-void ipc_dispatcher_add(enum ipc_dispatcher_id id, ipc_dispatcher_cb_t cb, void *param);
-void ipc_dispatcher_rm(enum ipc_dispatcher_id id);
+void ipc_dispatcher_add(uint32_t id, ipc_dispatcher_cb_t cb, void *param);
+void ipc_dispatcher_rm(uint32_t id);
 int ipc_dispatcher_send(const void *data, size_t len);
-
-/* Macros to pack/unpack the different types */
-
-#define IPC_DISPATCHER_PACK_FIELD(buff, field)                                 \
-do {                                                                           \
-	memcpy(buff, &field, sizeof(field));                                       \
-	buff += sizeof(field);                                                     \
-} while (0)
-
-#define IPC_DISPATCHER_UNPACK_FIELD(buff, field)                               \
-do {                                                                           \
-	memcpy(&field, buff, sizeof(field));                                       \
-	buff += sizeof(field);                                                     \
-} while (0)
-
-/* Macros for init ipc data in driver */
-
-#define IPC_DISPATCHER_HOST_INIT                                               \
-static K_MUTEX_DEFINE(ipc_mutex);                                              \
-static K_SEM_DEFINE(ipc_resp_sem, 0, 1)
-
-/* Macros for sending data from host device to remote */
-
-#define IPC_DISPATCHER_HOST_SEND_DATA(name, tx_buff, rx_buff, timeout_ms)      \
-do {                                                                           \
-	/* Nested callback */                                                      \
-	void resp_cb(const void *data, size_t len, void *param)                    \
-	{                                                                          \
-		unpack_##name(param, data, len);                                       \
-		k_sem_give(&ipc_resp_sem);                                             \
-	}                                                                          \
-                                                                               \
-	uint8_t packed_data[pack_##name(NULL, NULL)];                              \
-	size_t packed_len = pack_##name(tx_buff, packed_data);                     \
-	enum ipc_dispatcher_id id = *(enum ipc_dispatcher_id *)packed_data;        \
-                                                                               \
-	k_mutex_lock(&ipc_mutex, K_FOREVER);                                       \
-	k_sem_reset(&ipc_resp_sem);                                                \
-	ipc_dispatcher_add(id, resp_cb, rx_buff);                                  \
-                                                                               \
-	if (ipc_dispatcher_send(packed_data, packed_len) != packed_len) {          \
-		ipc_dispatcher_rm(id);                                                 \
-		k_mutex_unlock(&ipc_mutex);                                            \
-		LOG_ERR("IPC data send error (id=%x)", id);                            \
-		return -ECANCELED;                                                     \
-	}                                                                          \
-                                                                               \
-	if (k_sem_take(&ipc_resp_sem,                                              \
-			K_MSEC(timeout_ms))) {                                             \
-		ipc_dispatcher_rm(id);                                                 \
-		k_mutex_unlock(&ipc_mutex);                                            \
-		LOG_ERR("IPC response timeout (id=%x)", id);                           \
-		return -ETIMEDOUT;                                                     \
-	}                                                                          \
-                                                                               \
-	ipc_dispatcher_rm(id);                                                     \
-	k_mutex_unlock(&ipc_mutex);                                                \
-} while (0)
-
-/* Macros for packing data without param (only id) */
-
-#define IPC_DISPATCHER_PACK_FUNC_WITHOUT_PARAM(name, ipc_id)                   \
-static size_t pack_##name(void *unpack_data, uint8_t *pack_data)               \
-{                                                                              \
-	if (pack_data != NULL) {                                                   \
-		enum ipc_dispatcher_id id = ipc_id;                                    \
-                                                                               \
-		IPC_DISPATCHER_PACK_FIELD(pack_data, id);                              \
-	}                                                                          \
-                                                                               \
-	return sizeof(enum ipc_dispatcher_id);                                     \
-}
-
-/* Macros for unpacking data only with error param */
-
-#define IPC_DISPATCHER_UNPACK_FUNC_ONLY_WITH_ERROR_PARAM(name)                 \
-static void unpack_##name(void *unpack_data,                                   \
-		const uint8_t *pack_data, size_t pack_data_len)                        \
-{                                                                              \
-	int *p_err = unpack_data;                                                  \
-	size_t expect_len = sizeof(enum ipc_dispatcher_id) + sizeof(*p_err);       \
-                                                                               \
-	if (expect_len != pack_data_len) {                                         \
-		*p_err = -EINVAL;                                                      \
-		return;                                                                \
-	}                                                                          \
-                                                                               \
-	pack_data += sizeof(enum ipc_dispatcher_id);                               \
-	IPC_DISPATCHER_UNPACK_FIELD(pack_data, *p_err);                            \
-}
 
 #endif /* IPC_DISPATCHER_H */


### PR DESCRIPTION
- Updated IPC driver interface
- Add support of multiple instances to Telink W91 GPIO driver.