### PR TITLE
soc: riscv: telink_w91: ipc: Fix driver timeout

### DIFF
--- a/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
@@ -98,7 +98,7 @@ do {                                                                           \
 	};                                                                         \
                                                                                \
 	int ipc_err = ipc_based_driver_send(ipc, packed_data, packed_len,          \
-		&ctx, CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);                 \
+		&ctx, timeout_ms);                                                     \
                                                                                \
 	if (ipc_err) {                                                             \
 		return ipc_err;                                                        \


### PR DESCRIPTION
Fixed IPC driver send request timeout.