### PR TITLE
samples: boards: tlsr9x: key_matrix: Reduce resources usage

### DIFF
--- a/samples/boards/tlsr9x/key_matrix/src/zephyr_key_matrix.h
+++ b/samples/boards/tlsr9x/key_matrix/src/zephyr_key_matrix.h
@@ -26,8 +26,7 @@ struct key_matrix_data {
 	uint8_t                      *buttons;
 	on_button_change_t            on_button_change;
 	void                         *context;
-	struct k_work                 work;
-	struct k_timer                timer;
+	struct k_work_delayable       work;
 };
 
 /*


### PR DESCRIPTION
Matrix keyboard can't be strictly periodically scanned due to user callbacks. In tat case we can skip using timer and use only delayed works.