### PR TITLE
drivers: pwm: pwm_b9x: Rework handling inverted output

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-common.dtsi
@@ -177,8 +177,7 @@
 &pwm0 {
 	status = "okay";
 	clock-frequency = <93750>;
-	pinctrl-0 = <&pwm_ch0_pb4_default>;
-	pinctrl-names = "default";
+	pinctrl-ch0 = <&pwm_ch0_pb4_default>;
 };
 
 &pspi {

--- a/boards/riscv/tlsr9528a/tlsr9528a-common.dtsi
+++ b/boards/riscv/tlsr9528a/tlsr9528a-common.dtsi
@@ -192,8 +192,7 @@
 &pwm0 {
 	status = "okay";
 	clock-frequency = <93750>;
-	pinctrl-0 = <&pwm_ch0_pd0_default>;
-	pinctrl-names = "default";
+	pinctrl-ch0 = <&pwm_ch0_pd0_default>;
 };
 
 &lspi {

--- a/dts/bindings/pwm/telink,b9x-pwm.yaml
+++ b/dts/bindings/pwm/telink,b9x-pwm.yaml
@@ -10,14 +10,29 @@ compatible: "telink,b9x-pwm"
 
 properties:
 
-  pinctrl-0:
+  pinctrl-ch0:
     type: phandles
-    required: true
+    description: PWM cahnnel 0 pincontrol
 
-  clock-frequency:
-    type: int
-    required: true
-    description: Default PWM Peripheral Clock frequency in Hz (is used if 32K Clock is disabled)
+  pinctrl-ch1:
+    type: phandles
+    description: PWM cahnnel 1 pincontrol
+
+  pinctrl-ch2:
+    type: phandles
+    description: PWM cahnnel 2 pincontrol
+
+  pinctrl-ch3:
+    type: phandles
+    description: PWM cahnnel 3 pincontrol
+
+  pinctrl-ch4:
+    type: phandles
+    description: PWM cahnnel 4 pincontrol
+
+  pinctrl-ch5:
+    type: phandles
+    description: PWM cahnnel 5 pincontrol
 
   clk32k-ch0-enable:
     type: boolean
@@ -42,6 +57,11 @@ properties:
   clk32k-ch5-enable:
     type: boolean
     description: Enable 32K Source Clock for PWM Channel 5
+
+  clock-frequency:
+    type: int
+    required: true
+    description: Default PWM Peripheral Clock frequency in Hz (is used if 32K Clock is disabled)
 
   channels:
     type: int


### PR DESCRIPTION
Telink driver pwm_b9x supports inverted PWM channel. So it's possible to use inverted PWM output together with inverted PWM polarity to achieve usual PWM. But in this case there was an issue with Pin Control:
- Pin Control is defined in pwm .dts node
- PWM polarity is defined in a child pwm_leds .dts node As result (in case of using inverted pin together with inverted polarity) PWM driver connects all output PWM pins but at this time PWM channel (defined in a child node pwm_leds) is not stated so we have high level at PWM output till starting PWM channel with inverted polarity. This issue produced blinking during SW startup.

Provided workaround was to read PWM child node - pwm_leds and init all PWM channels before output pin connecting. The main drawback was that it's ​definitely to use child node (no possibility to use pwm without pwm_leds) and it breaks driver fundamentals it should be possible to use parent driver without its child.

Now, instead using workaround, pwm pin control is splitted into parts for each channel. And each channel's output is connected in time when this channel is configured (not during PWM driver start).