### PR TITLE
soc: riscv: telink_w91: Fix HW_CYCLES_PER_SEC value

### DIFF
--- a/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
@@ -10,6 +10,7 @@ zephyr_sources(
 	soc_irq.S
 	soc.c
 	halt.c
+	sw_sleep.c
 	sys_heap_alloc_wrap.c
 )
 

--- a/soc/riscv/riscv-privilege/telink_w91/soc.c
+++ b/soc/riscv/riscv-privilege/telink_w91/soc.c
@@ -7,9 +7,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 
-/* List of supported CCLK frequencies */
-#define CLK_160MHZ                        160000000u
-
 /* Check System Clock value. */
 #if (DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency) != CLK_160MHZ)
 	#error "Unsupported clock-frequency. Supported values: 160 MHz"

--- a/soc/riscv/riscv-privilege/telink_w91/soc.h
+++ b/soc/riscv/riscv-privilege/telink_w91/soc.h
@@ -13,4 +13,7 @@
 #define NDS_MCACHE_CTL              0x7ca
 #define NDS_MMISC_CTL               0x7d0
 
+/* List of supported CCLK frequencies */
+#define CLK_160MHZ                  160000000u
+
 #endif /* RISCV_TELINK_W91_SOC_H */

--- a/soc/riscv/riscv-privilege/telink_w91/sw_sleep.c
+++ b/soc/riscv/riscv-privilege/telink_w91/sw_sleep.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#define ASM_NOP_CLOCK_PER_CYCLE           10u
+#define ASM_NOP_CYCLES_PER_SEC            (CLK_160MHZ / ASM_NOP_CLOCK_PER_CYCLE)
+
+void __GENERIC_SECTION(.ram_code) __attribute__((noinline)) w91_sw_delay(uint32_t ms)
+{
+	/* Convert the check state period to approximate number of "nop" instructions */
+	uint32_t nop_count = ms * (ASM_NOP_CYCLES_PER_SEC / MSEC_PER_SEC);
+	
+	for (uint32_t i = 0; i < nop_count; i++) {
+		__asm volatile("nop");
+	}
+}
+
+

--- a/soc/riscv/riscv-privilege/telink_w91/sw_sleep.h
+++ b/soc/riscv/riscv-privilege/telink_w91/sw_sleep.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RISCV_TELINK_W91_SW_SLEEP_H
+#define RISCV_TELINK_W91_SW_SLEEP_H
+
+void w91_sw_delay(uint32_t ms);
+
+#endif /* RISCV_TELINK_W91_SW_SLEEP_H */


### PR DESCRIPTION
Fixed CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC value