### PR TITLE
west.yml: Modify BLE driver for B95

### DIFF
--- a/drivers/ieee802154/ieee802154_b9x.c
+++ b/drivers/ieee802154/ieee802154_b9x.c
@@ -1046,7 +1046,9 @@ static int b9x_stop(const struct device *dev)
 		riscv_plic_irq_disable(DT_INST_IRQN(0) - CONFIG_2ND_LVL_ISR_TBL_OFFSET);
 		rf_set_tx_rx_off();
 		rf_baseband_reset();
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92
 		rf_reset_dma();
+#endif
 		b9x->is_started = false;
 		if (b9x->event_handler) {
 			b9x->event_handler(dev, IEEE802154_EVENT_SLEEP, NULL);

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: e42cb25a0bfae5693ed4e7cc2e975aace4481ec4
+      revision: 1c110b892f438ed491d480ea8fd0f4eb8f5ecfe1
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- Reset Radio APIs for B95.
- driver: ieee802154: invoke different rf reset APIs based on different chip platform.