### PR TITLE
soc: riscv: telink_w91: Fix mcuboot

### DIFF
--- a/.github/workflows/telink-w91-build.yaml
+++ b/.github/workflows/telink-w91-build.yaml
@@ -58,12 +58,25 @@ jobs:
         cd ..
         west build -b tlsr9118bdk40d             -d build_nvs_w91                       zephyr/samples/subsys/nvs
 
+    - name: Build W91 bootloader/mcuboot/boot
+      run: |
+        cd ..
+        west build -b tlsr9118bdk40d             -d build_mcuboot_w91                   bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_LOG_DEFAULT_LEVEL=3
+
+    - name: Build W91 basic/blinky for DFU
+      run: |
+        cd ..
+        west build -b tlsr9118bdk40d             -d build_blinky_dfu_w91                zephyr/samples/basic/blinky                              -- -DCONFIG_BOOTLOADER_MCUBOOT=y
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
         cp ../build_blinky_w91/zephyr/zephyr.bin                    telink_build_artifacts/w91_blinky.bin
         cp ../build_button_w91/zephyr/zephyr.bin                    telink_build_artifacts/w91_button.bin
         cp ../build_mpu6050_w91/zephyr/zephyr.bin                   telink_build_artifacts/w91_mpu6050.bin
+        cp ../build_nvs_w91/zephyr/zephyr.bin                       telink_build_artifacts/w91_nvs.bin
+        cp ../build_mcuboot_w91/zephyr/zephyr.bin                   telink_build_artifacts/w91_mcuboot.bin
+        cp ../build_blinky_dfu_w91/zephyr/zephyr.signed.bin         telink_build_artifacts/w91_blinky_dfu.signed.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v3

--- a/soc/riscv/riscv-privilege/telink_w91/start.S
+++ b/soc/riscv/riscv-privilege/telink_w91/start.S
@@ -10,6 +10,8 @@
 #include "soc.h"
 
 #define N22_CORE_START (DT_REG_ADDR(DT_CHOSEN(zephyr_flash)) + DT_REG_SIZE(DT_CHOSEN(zephyr_flash)))
+#define IPC_REMOTE_TX_START (DT_REG_ADDR(DT_N_NODELABEL_sram_rx))
+#define IPC_REMOTE_TX_END (IPC_REMOTE_TX_START + DT_REG_SIZE(DT_N_NODELABEL_sram_rx))
 
 	.option push
 	.option norelax
@@ -23,16 +25,30 @@ reset_vector:
 	.global _start
 	.type _start,@function
 
-	.word (0x31707848)	               #/ magic
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT)
+	.word (0x31707848)                 #/ magic
 	.word (0x33e90d91)                 #/ header crc32
 	.org 0x14
 	.word (0xa0000080)                 #/ start address
 
 	.org 0xa0
+#endif
+
 _start:                                #/ after reset starts on D25 core
 
+	lui    t0, 0
+	la     t2, IPC_REMOTE_TX_START
+	la     t3, IPC_REMOTE_TX_END
+_ZERO_IPC_REMOTE_TX_BEGIN:
+	bleu   t3, t2, _start_n22
+	sw     t0, 0(t2)
+	addi   t2, t2, 4
+	j      _ZERO_IPC_REMOTE_TX_BEGIN
+
+_start_n22:
+
 	lui    t0, 0xf0100
-	lui	   t1, %hi(N22_CORE_START)
+	lui    t1, %hi(N22_CORE_START)
 	addi   t1, t1, %lo(N22_CORE_START)
 	sw     t1, 0x204(t0)               #/ N22 core address: 0xf0100204 <- N22_CORE_START
 	lui    t0, 0xf1700


### PR DESCRIPTION
- clear IPC remote TX buffer every boot
- use magic and header only for bootable image
- add mcuboot related CI tasks