### PR TITLE
Add W91 heartbeat module

### DIFF
--- a/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
@@ -27,6 +27,12 @@ zephyr_sources(
 )
 endif()
 
+if(CONFIG_TELINK_W91_CORE_HEARTBEAT)
+zephyr_sources(
+	core_heartbeat/core_heartbeat.c
+)
+endif()
+
 if(CONFIG_TELINK_W91_DEBUG_ENABLE)
 zephyr_sources(
 	debug.c

--- a/soc/riscv/riscv-privilege/telink_w91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_w91/Kconfig.soc
@@ -97,3 +97,5 @@ config TELINK_W91_DEBUG_BAUDRATE
 source "soc/riscv/riscv-privilege/telink_w91/ipc/Kconfig.ipc"
 
 source "soc/riscv/riscv-privilege/telink_w91/blocking_core/Kconfig.blocking"
+
+source "soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat"

--- a/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
+++ b/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
@@ -1,0 +1,32 @@
+# Copyright (c) 2024 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config TELINK_W91_CORE_HEARTBEAT
+	bool "Telink W91 intercore heartbeat"
+	default y
+	help
+		This option enables Telink W91 heartbeat messages between cores.
+
+config TELINK_W91_CORE_HEARTBEAT_THREAD_STACK_SIZE
+	int "Core heartbeat thread stack size"
+	default 512
+	help
+	  Core heartbeat stack size.
+
+config TELINK_W91_CORE_HEARTBEAT_THREAD_PRIORITY
+	int "Core heartbeat thread priority"
+	default 10
+	help
+	  Core heartbeat thread priority.
+
+config CORE_HEARTBEAT_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
+	int "Telink IPC dispatcher timeout while waiting on the N22 response"
+	default 200
+	help
+	  This option sets Telink IPC dispatcher response driver timeout in mS.
+
+config CORE_HEARTBEAT_TELINK_W91_TIMEOUT_MS
+	int "Hearbeat signal interval, ms"
+	default 1000
+	help
+	  This option sets heartbeat timeout in mS.

--- a/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/core_heartbeat.c
+++ b/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/core_heartbeat.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <ipc/ipc_based_driver.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(heartbeat);
+
+static struct ipc_based_driver ipc_data;
+static struct k_thread heartbeat_thread_data;
+
+K_THREAD_STACK_DEFINE(heartbeat_thread_stack, CONFIG_TELINK_W91_CORE_HEARTBEAT_THREAD_STACK_SIZE);
+
+static size_t pack_heartbeat_w91(uint8_t inst, void *unpack_data, uint8_t *pack_data)
+{
+	size_t pack_data_len = sizeof(uint32_t);
+
+	if (pack_data != NULL) {
+		uint32_t id = IPC_DISPATCHER_MK_ID(IPC_DISPATCHER_HEARTBEAT, inst);
+
+		IPC_DISPATCHER_PACK_FIELD(pack_data, id);
+	}
+
+	return pack_data_len;
+}
+
+IPC_DISPATCHER_UNPACK_FUNC_ONLY_WITH_ERROR_PARAM(heartbeat_w91);
+
+static void heartbeat_w91_thread(void *p1, void *p2, void *p3)
+{
+	while (1) {
+		bool heartbeat_response_status = 0;
+
+		IPC_DISPATCHER_HOST_SEND_DATA(
+			&ipc_data, 0, heartbeat_w91, NULL, &heartbeat_response_status,
+			CONFIG_CORE_HEARTBEAT_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+
+		if (!heartbeat_response_status) {
+#ifdef CONFIG_LOG
+			LOG_ERR("No response from core N22, rebooting...\n");
+			k_msleep(100);
+#else
+			printk("[E] No response from core N22, rebooting...\n");
+#endif
+			/* board reboots */
+			sys_reboot(0);
+		}
+
+		k_msleep(CONFIG_CORE_HEARTBEAT_TELINK_W91_TIMEOUT_MS);
+	}
+}
+
+static int heartbeat_w91_init(void)
+{
+	ipc_based_driver_init(&ipc_data);
+
+	k_thread_create(&heartbeat_thread_data, heartbeat_thread_stack,
+			K_THREAD_STACK_SIZEOF(heartbeat_thread_stack), heartbeat_w91_thread, NULL,
+			NULL, NULL, CONFIG_TELINK_W91_CORE_HEARTBEAT_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	return 0;
+}
+
+SYS_INIT(heartbeat_w91_init, POST_KERNEL, CONFIG_TELINK_W91_IPC_PRE_DRIVERS_INIT_PRIORITY);

--- a/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
@@ -23,6 +23,7 @@ enum ipc_dispatcher_id {
 	IPC_DISPATCHER_FLASH                    = 0x700,
 	IPC_DISPATCHER_BLOCKING                 = 0x800,
 	IPC_DISPATCHER_WIFI                     = 0x900,
+	IPC_DISPATCHER_HEARTBEAT                = 0xA00,
 } __attribute__((__packed__));
 
 typedef void (*ipc_based_driver_unpack_t)(void *result, const uint8_t *data, size_t len);


### PR DESCRIPTION
Added status-check module between D25 and N22 cores for Telink W91 board.
IPC used for signal ping-pong.
Board reboots in case of no response (crash, UB etc) after a certain timeout.