### PR TITLE
drivers: hwinfo: spi-flash-id: add hwinfo driver

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -7,6 +7,7 @@ zephyr_library_sources_ifdef(CONFIG_HWINFO             hwinfo_weak_impl.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SHELL       hwinfo_shell.c)
 
 zephyr_library_sources_ifdef(CONFIG_HWINFO_TELINK_B9X  hwinfo_b9x.c)
+zephyr_library_sources_ifdef(CONFIG_HWINFO_TELINK_W91  hwinfo_w91.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_ESP32       hwinfo_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_GECKO       hwinfo_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_IMXRT       hwinfo_imxrt.c)

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -150,6 +150,13 @@ config HWINFO_ANDES
 	help
 	  Enable Andes hwinfo driver
 
+config HWINFO_TELINK_W91
+	bool "Telink W91 device ID"
+	default y
+	depends on SOC_SERIES_RISCV_TELINK_W91
+	help
+	  Enable Telink B9x hwinfo driver.
+
 endif
 
 config HWINFO_TELINK_B9X

--- a/drivers/hwinfo/hwinfo_w91.c
+++ b/drivers/hwinfo/hwinfo_w91.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021-2023 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <stdint.h>
+
+#define SPI_FLASH_HWINFO_ID_LEN ((size_t)6)
+
+extern uint32_t flash_w91_get_id(const struct device *dev, uint32_t *flash_id);
+
+
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	ssize_t result = length;
+	uint32_t chip_id_val = 0;
+	const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+
+	if (length < SPI_FLASH_HWINFO_ID_LEN) {
+		printk("Not enougth buffer size to get the hwinfo (ID).\n\r");
+		result = 0;
+	} else {
+		result = (size_t)flash_w91_get_id(flash_dev, &chip_id_val);
+	}
+
+	/* Check device ID value and store it into the buffer */
+	if ((chip_id_val != 0) && (result == (size_t)0)) {
+		memcpy(buffer, &chip_id_val, SPI_FLASH_HWINFO_ID_LEN);
+		result = SPI_FLASH_HWINFO_ID_LEN;
+	} else {
+		printk("Flash hw INFO get ID read failed!\n");
+		result = 0;
+	}
+
+	return result;
+}


### PR DESCRIPTION
- Added hwinfo driver for the w91 board

- Extend soc_flash_w91 API driver
- Signed-off-by: Borys Nykytiuk <borys.nykytiuk@telink-semi.com>