### PR TITLE
drivers: wif: telink: Kconfig.w91: Fix priority

### DIFF
--- a/drivers/wifi/telink/Kconfig.w91
+++ b/drivers/wifi/telink/Kconfig.w91
@@ -25,7 +25,7 @@ config TELINK_W91_WIFI_EVENT_THREAD_STACK_SIZE
 
 config TELINK_W91_WIFI_EVENT_THREAD_PRIORITY
 	int "WIFI event thread priority"
-	default 20
+	default 10
 	help
 	  WIFI event thread priority.
 


### PR DESCRIPTION
Set allowed thread priority. By default allowed priorities are in range: 14 to -16. As result it leads to crash at init when CONFIG_ASSERT=y