### PR TITLE
W91 heartbeat issue

### DIFF
--- a/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
+++ b/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
@@ -15,18 +15,18 @@ config TELINK_W91_CORE_HEARTBEAT_THREAD_STACK_SIZE
 
 config TELINK_W91_CORE_HEARTBEAT_THREAD_PRIORITY
 	int "Core heartbeat thread priority"
-	default 10
+	default 5
 	help
 	  Core heartbeat thread priority.
 
 config CORE_HEARTBEAT_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
 	int "Telink IPC dispatcher timeout while waiting on the N22 response"
-	default 200
+	default 10
 	help
 	  This option sets Telink IPC dispatcher response driver timeout in mS.
 
 config CORE_HEARTBEAT_TELINK_W91_TIMEOUT_MS
-	int "Hearbeat signal interval, ms"
-	default 1000
+	int "Heartbeat signal interval, ms"
+	default 800
 	help
 	  This option sets heartbeat timeout in mS.

--- a/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/ipc_based_driver.h
@@ -123,7 +123,7 @@ do {                                                                           \
 		&ctx, timeout_ms);                                                     \
                                                                                \
 	if (ipc_err) {                                                             \
-		assert(0);                                                             \
+		/* TODO: Add assert after IPv6 FreeRTOS implemented: assert(0); */     \
 	}                                                                          \
 } while (0)
 


### PR DESCRIPTION
False core-stop events took place after flash-memory ops request blocking (Matter mostly)
Fixes http://192.168.48.49:8080/browse/ZEPHYR-537

assert() call removed in ipc_based_driver in order to prevent fail upon IPv6 usage in Matter.
Should be introduced further after that will be done in FreeRTOS side