### PR TITLE
drivers: wif: telink: Add WiFi state functionality

### DIFF
--- a/drivers/wifi/telink/wifi_w91.h
+++ b/drivers/wifi/telink/wifi_w91.h
@@ -43,6 +43,7 @@ struct wifi_w91_data_base {
 #if CONFIG_NET_DHCPV4
 	struct net_mgmt_event_callback ev_dhcp;
 #endif /*CONFIG_NET_DHCPV4 */
+	struct wifi_iface_status if_state;
 };
 
 struct wifi_w91_data_l2 {


### PR DESCRIPTION
Implemented iface_status driver API. It allows to retrieve WiFi current status using net_mgmt NET_REQUEST_WIFI_IFACE_STATUS