### PR TITLE
soc: riscv: telink_w91: Set IPC dispatcher common timeout

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.w91
+++ b/drivers/bluetooth/hci/Kconfig.w91
@@ -9,12 +9,6 @@ config BLE_HCI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
 	help
 	  This option sets Telink IPC dispatcher response driver timeout in mS.
 
-config BLE_HCI_TELINK_W91_IPC_SEND_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response for sending data"
-	default 50
-	help
-	  This option sets Telink IPC send dispatcher response driver timeout for sending data in mS.
-
 config BT_ATT_ENFORCE_FLOW
 	default n
 

--- a/drivers/bluetooth/hci/hci_w91.c
+++ b/drivers/bluetooth/hci/hci_w91.c
@@ -73,7 +73,7 @@ static int hci_w91_open(void)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&ipc_data, 0,
 			hci_w91_open, mac, &err,
-			CONFIG_BLE_HCI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	if (err == 0) {
 		bt_ctrl_state = W91_BT_CTRL_STATE_ACTIVATED;
@@ -102,7 +102,7 @@ static int hci_w91_close(void)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&ipc_data, 0,
 			hci_w91_close, NULL, &err,
-			CONFIG_BLE_HCI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	if (err == 0) {
 		bt_ctrl_state = W91_BT_CTRL_STATE_STOPPED;
@@ -167,7 +167,7 @@ static int hci_w91_send(struct net_buf *buf)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&ipc_data, 0,
 		hci_w91_send, &send_req, &err,
-		CONFIG_BLE_HCI_TELINK_W91_IPC_SEND_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	net_buf_unref(buf);
 	return err;

--- a/drivers/entropy/Kconfig.w91
+++ b/drivers/entropy/Kconfig.w91
@@ -10,13 +10,3 @@ config ENTROPY_TELINK_W91_TRNG
 	select ENTROPY_HAS_DRIVER
 	help
 	  Enable the W91-series Entropy driver.
-
-if ENTROPY_TELINK_W91_TRNG
-
-config ENTROPY_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 10
-	help
-	  This option sets Telink IPC dispatcher response driver timeout in mS.
-
-endif # ENTROPY_TELINK_W91_TRNG

--- a/drivers/entropy/entropy_w91_trng.c
+++ b/drivers/entropy/entropy_w91_trng.c
@@ -99,7 +99,7 @@ static int entropy_w91_trng_get_entropy(const struct device *dev,
 		IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 				entropy_w91_trng_get_entropy,
 				&entropy_length, &trng_get_entropy_resp,
-				CONFIG_ENTROPY_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+				CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 		if (trng_get_entropy_resp.err || (length <= ENTROPY_TRNG_MAX_SIZE_IN_PACK)) {
 			break;

--- a/drivers/flash/Kconfig.w91
+++ b/drivers/flash/Kconfig.w91
@@ -9,13 +9,3 @@ config SOC_FLASH_TELINK_W91
 	select FLASH_HAS_DRIVER_ENABLED
 	help
 	  Enables Telink W91 flash driver.
-
-if SOC_FLASH_TELINK_W91
-
-config FLASH_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 1000
-	help
-	  This option sets Telink IPC dispatcher response driver timeout in mS.
-
-endif # SOC_FLASH_TELINK_W91

--- a/drivers/flash/soc_flash_w91.c
+++ b/drivers/flash/soc_flash_w91.c
@@ -116,7 +116,7 @@ static int flash_w91_erase(const struct device *dev, off_t offset, size_t len)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 			flash_w91_erase, &erase_req, &err,
-			CONFIG_FLASH_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	blocking_event_rm();
 
@@ -172,7 +172,7 @@ static int flash_w91_write(const struct device *dev, off_t offset, const void *d
 
 		IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 				flash_w91_write, &write_req, &err,
-				CONFIG_FLASH_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+				CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 		blocking_event_rm();
 
@@ -258,7 +258,7 @@ static int flash_w91_read(const struct device *dev, off_t offset, void *data, si
 
 		IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 				flash_w91_read, &read_req, &read_resp,
-				CONFIG_FLASH_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+				CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 		blocking_event_rm();
 
@@ -309,7 +309,7 @@ int flash_w91_get_id(const struct device *dev, uint8_t *hw_id)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 			flash_w91_get_id, NULL, &read_resp,
-			CONFIG_FLASH_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	if (read_resp.err != 0) {
 		LOG_ERR("Flash get ID operation failed");

--- a/drivers/gpio/Kconfig.w91
+++ b/drivers/gpio/Kconfig.w91
@@ -9,13 +9,3 @@ config GPIO_TELINK_W91
 	depends on DT_HAS_TELINK_W91_GPIO_ENABLED && TELINK_W91_IPC_DISPATCHER
 	help
 		Enables the W91-series GPIO driver.
-
-if GPIO_TELINK_W91
-
-config GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 10
-	help
-		This option sets Telink IPC dispatcher response driver timeout in mS.
-
-endif # GPIO_TELINK_W91

--- a/drivers/gpio/gpio_w91.c
+++ b/drivers/gpio/gpio_w91.c
@@ -160,7 +160,7 @@ static int gpio_w91_pin_configure(const struct device *dev,
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		gpio_w91_pin_configure, &pin_config_req, &err,
-		CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -194,7 +194,7 @@ static int gpio_w91_port_get_raw(const struct device *dev, gpio_port_value_t *va
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		gpio_w91_port_get_raw, NULL, &port_get_raw_resp,
-		CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	if (!port_get_raw_resp.err) {
 		*value = port_get_raw_resp.value;
@@ -240,7 +240,7 @@ static int gpio_w91_port_set_masked_raw(const struct device *dev,
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		gpio_w91_port_set_masked_raw, &port_set_masked_raw_req, &err,
-		CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -272,7 +272,7 @@ static int gpio_w91_port_set_bits_raw(const struct device *dev, gpio_port_pins_t
 	uint8_t inst = ((struct gpio_w91_config *)dev->config)->instance_id;
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst, gpio_w91_port_set_bits_raw, &mask, &err,
-		CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -304,7 +304,7 @@ static int gpio_w91_port_clear_bits_raw(const struct device *dev, gpio_port_pins
 	uint8_t inst = ((struct gpio_w91_config *)dev->config)->instance_id;
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst, gpio_w91_port_clear_bits_raw, &mask, &err,
-		CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -336,7 +336,7 @@ static int gpio_w91_port_toggle_bits(const struct device *dev, gpio_port_pins_t 
 	uint8_t inst = ((struct gpio_w91_config *)dev->config)->instance_id;
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst, gpio_w91_port_toggle_bits, &mask, &err,
-		CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -402,7 +402,7 @@ static int gpio_w91_pin_interrupt_configure(const struct device *dev,
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		gpio_w91_pin_interrupt_configure, &pin_irq_config_req, &err,
-		CONFIG_GPIO_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }

--- a/drivers/i2c/Kconfig.w91
+++ b/drivers/i2c/Kconfig.w91
@@ -7,19 +7,3 @@ config I2C_TELINK_W91
 	depends on DT_HAS_TELINK_W91_I2C_ENABLED
 	help
 	  Enables Telink W91 I2C driver.
-
-if I2C_TELINK_W91
-
-config I2C_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 10
-	help
-		This option sets Telink IPC dispatcher response driver timeout in mS.
-
-config I2C_TELINK_W91_IPC_MASTER_RX_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher Master RX timeout waiting for endpoint response"
-	default 200
-	help
-		This option sets Telink IPC dispatcher master RX response timeout in mS.
-
-endif # I2C_TELINK_W91

--- a/drivers/i2c/i2c_w91.c
+++ b/drivers/i2c/i2c_w91.c
@@ -108,7 +108,7 @@ static int i2c_w91_ipc_configure(const struct device *dev, uint32_t clock_speed)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		i2c_w91_ipc_configure, &i2c_config, &err,
-		CONFIG_I2C_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -160,7 +160,7 @@ static int i2c_w91_ipc_master_read(const struct device *dev, uint16_t addr, uint
 	uint8_t inst = ((struct i2c_w91_cfg *)dev->config)->instance_id;
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst, i2c_w91_ipc_master_read, &rx_req, &rx_resp,
-				      CONFIG_I2C_TELINK_W91_IPC_MASTER_RX_RESPONSE_TIMEOUT_MS);
+				      CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 	if (rx_resp.err != 0) {
 		LOG_ERR("RX failed, ret(%d)", rx_resp.err);
 	}
@@ -201,7 +201,7 @@ static int i2c_w91_ipc_master_write(const struct device *dev, uint16_t addr, uin
 	uint8_t inst = ((struct i2c_w91_cfg *)dev->config)->instance_id;
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst, i2c_w91_ipc_master_write, &i2c_master_tx,
-				      &err, CONFIG_I2C_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+				      &err, CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 	return err;
 }
 

--- a/drivers/pinctrl/Kconfig.w91
+++ b/drivers/pinctrl/Kconfig.w91
@@ -7,13 +7,3 @@ config PINCTRL_TELINK_W91
 	depends on DT_HAS_TELINK_W91_PINCTRL_ENABLED
 	help
 	  Enables Telink W91-series pin controller driver
-
-if PINCTRL_TELINK_W91
-
-config PINCTRL_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 10
-	help
-	  This option sets Telink IPC dispatcher response driver timeout in mS.
-
-endif # PINCTRL_TELINK_W91

--- a/drivers/pinctrl/pinctrl_w91.c
+++ b/drivers/pinctrl/pinctrl_w91.c
@@ -60,7 +60,7 @@ static int pinctrl_w91_pin_configure(uint8_t pin, uint8_t func)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&ipc_data, 0,
 			pinctrl_w91_pin_configure, &pin_config_req, &err,
-			CONFIG_PINCTRL_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }

--- a/drivers/pwm/Kconfig.w91
+++ b/drivers/pwm/Kconfig.w91
@@ -7,13 +7,3 @@ config PWM_TELINK_W91
 	depends on DT_HAS_TELINK_W91_PWM_ENABLED
 	help
 	  Enables Telink W91 PWM driver.
-
-if PWM_TELINK_W91
-
-config PWM_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 10
-	help
-		This option sets Telink IPC dispatcher response driver timeout in mS.
-
-endif # PWM_TELINK_W91

--- a/drivers/pwm/pwm_w91.c
+++ b/drivers/pwm/pwm_w91.c
@@ -81,7 +81,7 @@ static int pwm_w91_ipc_configure(const struct device *dev, uint32_t channel,
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		pwm_w91_ipc_configure, &pwm_config_req, &err,
-		CONFIG_PWM_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -136,13 +136,13 @@ static int pwm_w91_init(const struct device *dev)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		timer0_ipc_wrap_get_speed, NULL, &timers_get_speed_resp,
-		CONFIG_PWM_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	data->timer0_clock_frequency = timers_get_speed_resp.value / FREQ_DIVIDER;
 
 	IPC_DISPATCHER_HOST_SEND_DATA(ipc_data, inst,
 		timer1_ipc_wrap_get_speed, NULL, &timers_get_speed_resp,
-		CONFIG_PWM_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	data->timer1_clock_frequency = timers_get_speed_resp.value / FREQ_DIVIDER;
 

--- a/drivers/wifi/telink/Kconfig.w91
+++ b/drivers/wifi/telink/Kconfig.w91
@@ -35,12 +35,6 @@ config TELINK_W91_WIFI_EVENT_MAX_MSG
 	help
 	  WIFI event max messages.
 
-config WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 10
-	help
-	  This option sets Telink IPC dispatcher response driver timeout in mS.
-
 config WIFI_TELINK_W91_IPV6_ADDR_CNT
 	int "Telink IPv6 address count"
 	default 8

--- a/drivers/wifi/telink/wifi_w91.c
+++ b/drivers/wifi/telink/wifi_w91.c
@@ -224,7 +224,7 @@ static int wifi_w91_set_ipv4(struct net_if *iface)
 		err = -ETIMEDOUT;
 		IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 			wifi_w91_set_ipv4, &ipv4, &err,
-			CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 	}
 
 	if (data->base.state == WIFI_W91_STA_CONNECTED) {
@@ -327,7 +327,7 @@ static int wifi_w91_set_ipv6(struct net_if *iface)
 		err = -ETIMEDOUT;
 		IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 			wifi_w91_set_ipv6, &ipv6, &err,
-			CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 	}
 
 	if (data->base.state == WIFI_W91_STA_CONNECTED) {
@@ -389,7 +389,7 @@ static void wifi_w91_init_if(struct net_if *iface)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 		wifi_w91_init_if, NULL, &init_resp,
-		CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	if (init_resp.err) {
 		LOG_ERR("Failed to start Wi-Fi driver (response status is incorrect)");
@@ -436,7 +436,7 @@ static int wifi_w91_scan(const struct device *dev, scan_result_cb_t cb)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 		wifi_w91_scan, NULL, &err,
-		CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 	if (!err) {
 		wifi_w91_reset_state(&data->base.if_state);
 		data->base.if_state.state = WIFI_STATE_SCANNING;
@@ -515,7 +515,7 @@ static int wifi_w91_connect(const struct device *dev, struct wifi_connect_req_pa
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 		wifi_w91_connect, &connect_req, &err,
-		CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 	if (!err) {
 		wifi_w91_reset_state(&data->base.if_state);
 		data->base.if_state.state = WIFI_STATE_AUTHENTICATING;
@@ -540,7 +540,7 @@ static int wifi_w91_disconnect(const struct device *dev)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 		wifi_w91_disconnect, NULL, &err,
-		CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -600,7 +600,7 @@ static int wifi_w91_ap_enable(const struct device *dev, struct wifi_connect_req_
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 		wifi_w91_ap_enable, &connect_req, &err,
-		CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }
@@ -620,7 +620,7 @@ static int wifi_w91_ap_disable(const struct device *dev)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&data->ipc, cfg->instance_id,
 		wifi_w91_ap_disable, NULL, &err,
-		CONFIG_WIFI_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }

--- a/soc/riscv/riscv-privilege/telink_w91/blocking_core/Kconfig.blocking
+++ b/soc/riscv/riscv-privilege/telink_w91/blocking_core/Kconfig.blocking
@@ -16,12 +16,6 @@ config TELINK_W91_BLOCKING_CORE_THREAD_STACK_SIZE
 	help
 	  Blocking thread stack size.
 
-config BLOCKING_CORE_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 10
-	help
-	  This option sets Telink IPC dispatcher response driver timeout in mS.
-
 config BLOCKING_CORE_TELINK_W91_CORE_STOP_TIMEOUT_MS
 	int "Core stop timeout"
 	default 100

--- a/soc/riscv/riscv-privilege/telink_w91/blocking_core/blocking.c
+++ b/soc/riscv/riscv-privilege/telink_w91/blocking_core/blocking.c
@@ -77,7 +77,7 @@ static int blocking_w91_set_state_addr(uint32_t addr)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(&ipc_data, 0,
 			blocking_w91_set_state_addr, &addr, &err,
-			CONFIG_BLOCKING_CORE_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	return err;
 }

--- a/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
+++ b/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
@@ -19,12 +19,6 @@ config TELINK_W91_CORE_HEARTBEAT_THREAD_PRIORITY
 	help
 	  Core heartbeat thread priority.
 
-config CORE_HEARTBEAT_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting on the N22 response"
-	default 10
-	help
-	  This option sets Telink IPC dispatcher response driver timeout in mS.
-
 config CORE_HEARTBEAT_TELINK_W91_TIMEOUT_MS
 	int "Heartbeat signal interval, ms"
 	default 800

--- a/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/core_heartbeat.c
+++ b/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/core_heartbeat.c
@@ -32,7 +32,7 @@ static void heartbeat_w91_thread(void *p1, void *p2, void *p3)
 
 		IPC_DISPATCHER_HOST_SEND_DATA(
 			&ipc_data, 0, heartbeat_w91_check, NULL, &heartbeat_response_status,
-			CONFIG_CORE_HEARTBEAT_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+			CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 		if (!heartbeat_response_status) {
 #ifdef CONFIG_LOG
@@ -62,7 +62,7 @@ static int heartbeat_w91_init(void)
 
 	IPC_DISPATCHER_HOST_SEND_DATA(
 		&ipc_data, 0, heartbeat_w91_start, NULL, &err,
-		CONFIG_CORE_HEARTBEAT_TELINK_W91_IPC_RESPONSE_TIMEOUT_MS);
+		CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 	if (err) {
 		return err;

--- a/soc/riscv/riscv-privilege/telink_w91/crypto/Kconfig.crypto
+++ b/soc/riscv/riscv-privilege/telink_w91/crypto/Kconfig.crypto
@@ -14,11 +14,4 @@ config TELINK_W91_ECC_HW_ACC
 	help
 		This option enables Telink W91 EC cryptography HW acceleration.
 
-config TELINK_W91_ECC_HW_ACC_IPC_RESPONSE_TIMEOUT_MS
-	int "Telink IPC dispatcher timeout while waiting from the endpoint response"
-	default 300
-	depends on TELINK_W91_ECC_HW_ACC
-	help
-		his option sets Telink IPC dispatcher response driver timeout in mS.
-
 endif # MBEDTLS

--- a/soc/riscv/riscv-privilege/telink_w91/crypto/ecp_alt_backend.c
+++ b/soc/riscv/riscv-privilege/telink_w91/crypto/ecp_alt_backend.c
@@ -128,7 +128,7 @@ int telink_w91_ecp_alt_check_pubkey(const mbedtls_ecp_group *grp,
 
 				IPC_DISPATCHER_HOST_SEND_DATA(&telink_w91_ecp_alt_ipc, 0,
 					telink_w91_ecp_alt_check_pubkey, &request, &result,
-					CONFIG_TELINK_W91_ECC_HW_ACC_IPC_RESPONSE_TIMEOUT_MS);
+					CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 				if (result && result != MBEDTLS_ERR_ECP_INVALID_KEY) {
 					LOG_ERR("%s failed on curve %s %d", __func__,
@@ -224,7 +224,7 @@ int telink_w91_ecp_alt_mul_restartable(mbedtls_ecp_group *grp,
 
 				IPC_DISPATCHER_HOST_SEND_DATA(&telink_w91_ecp_alt_ipc, 0,
 					telink_w91_ecp_alt_mul_restartable, &request, &response,
-					CONFIG_TELINK_W91_ECC_HW_ACC_IPC_RESPONSE_TIMEOUT_MS);
+					CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 				result = response.err;
 				if (!result) {
@@ -330,7 +330,7 @@ int telink_w91_ecp_alt_muladd_restartable(mbedtls_ecp_group *grp,
 
 				IPC_DISPATCHER_HOST_SEND_DATA(&telink_w91_ecp_alt_ipc, 0,
 					telink_w91_ecp_alt_muladd_restartable, &request, &response,
-					CONFIG_TELINK_W91_ECC_HW_ACC_IPC_RESPONSE_TIMEOUT_MS);
+					CONFIG_TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS);
 
 				result = response.err;
 				if (!result) {

--- a/soc/riscv/riscv-privilege/telink_w91/ipc/Kconfig.ipc
+++ b/soc/riscv/riscv-privilege/telink_w91/ipc/Kconfig.ipc
@@ -42,6 +42,13 @@ config TELINK_W91_IPC_DISPATCHER_BOUND_TIMEOUT_MS
 	help
 		This option sets Telink IPC dispatcher bound timeout in mS.
 
+config TELINK_W91_IPC_DISPATCHER_TIMEOUT_MS
+	int "Telink IPC dispatcher timeout"
+	default 1500
+	depends on TELINK_W91_IPC_DISPATCHER
+	help
+		This option sets Telink IPC dispatcher requests timeout in mS.
+
 config IPC_SERVICE_ICMSG_CB_BUF_SIZE
 	default 1504 if WIFI_W91
 	default 1024


### PR DESCRIPTION
IPC has only one reception thread and all drivers functionality are executed from this thread. But each driver had individual timeout. This was not correct because when we try to execute some fast driver function (with low timeout) IPC can be blocked by execution some slow driver function (with high timeout).
As result we had IPC timeout and driver function fails. To overcome the issue all these drivers are using common timeout which is set to higher IPC timeout value.