### PR TITLE
drivers: I2C: Update pull-up pin config for the i2c device tree

### DIFF
--- a/boards/riscv/tlsr9528a/tlsr9528a-pinctrl.dtsi
+++ b/boards/riscv/tlsr9528a/tlsr9528a-pinctrl.dtsi
@@ -75,10 +75,12 @@
 	/* Define I2C pins: SCL(PC0), SDA(PC1) */
 
 	i2c_scl_pc0_default: i2c_scl_pc0_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_0, B92_FUNC_I2C_SCL_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_0,
+					(B92_FUNC_I2C_SCL_IO | B92_PULL_UP))>;
 	};
 	i2c_sda_pc1_default: i2c_sda_pc1_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_1, B92_FUNC_I2C_SDA_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_1,
+					(B92_FUNC_I2C_SDA_IO | B92_PULL_UP))>;
 	};
 
 	/* Define ADC pins: PB0..PB7, PD0-PD1 */

--- a/include/zephyr/dt-bindings/pinctrl/b92-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/b92-pinctrl.h
@@ -129,6 +129,7 @@
 #define B9x_PIN_ID_MSK   0xFF
 
 /* Setters and getters */
+#define B92_PULL_UP      (B9x_PULL_UP << (B9x_PULL_POS - B9x_FUNC_POS))
 
 #define B9x_PINMUX_SET(port, pin, func)   ((func << B9x_FUNC_POS) | \
 					   (port << B9x_PORT_POS) | \


### PR DESCRIPTION
Modify pinctrl device tree and pinctrl b92 header