### PR TITLE
telink: blobs: Update blobs location.

### DIFF
--- a/.github/workflows/telink-b95-build.yaml
+++ b/.github/workflows/telink-b95-build.yaml
@@ -108,7 +108,6 @@ jobs:
         cp ../build_ot_echo_server_b95/zephyr/zephyr.bin            telink_build_artifacts/b95_ot_echo_server.bin
         cp ../build_ot_echo_client_b95/zephyr/zephyr.bin            telink_build_artifacts/b95_ot_echo_client.bin
         cp ../build_usb_console_b95/zephyr/zephyr.bin               telink_build_artifacts/b95_usb_console.bin
-        cp ../modules/hal/telink/zephyr/blobs/liblt_9258_zephyr.a   telink_build_artifacts/liblt_9258_zephyr.a
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v3

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 36283106d9b0b1d5fb3025a98be5a58007ac3d77
+      revision: e31885b0369109e32955f967016b2b391f032d00
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Now Telink blobs are stored at wiki.telink-semi.cn