### PR TITLE
soc: riscv: telink_w91: Kconfig.n22: Update N22

### DIFF
--- a/soc/riscv/riscv-privilege/telink_w91/Kconfig.n22
+++ b/soc/riscv/riscv-privilege/telink_w91/Kconfig.n22
@@ -10,7 +10,7 @@ config TELINK_W91_FETCH_N22_BIN
 
 config TELINK_W91_FETCH_N22_BIN_REVISION
 	string "N22 binaries revision"
-	default "7a23b229737950b74c9acca21a07c6bcc5b071e6"
+	default "104753327acb5e39225bcd517af8d27ee644c5ef"
 	depends on TELINK_W91_FETCH_N22_BIN
 	help
 		This option sets N22 binary revision.


### PR DESCRIPTION
Update N22 FW binary. Fixed scanning result delivery.