### PR TITLE
optimized zephyr NVS loopup

### DIFF
--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -27,6 +27,15 @@ config NVS_LOOKUP_CACHE_SIZE
 	  Number of entries in Non-volatile Storage lookup cache.
 	  It is recommended that it be a power of 2.
 
+config NVS_LOOKUP_CACHE_ARRAY_SIZE
+	int "Non-volatile Storage lookup cache size"
+	default 128
+	range 1 65536
+	depends on NVS_LOOKUP_CACHE
+	help
+	  Number of entries in Non-volatile Storage lookup cache.
+	  It is recommended that it be a power of 2.
+
 module = NVS
 module-str = nvs
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
just for review , don't merge .
For the case TC_RR_1.1 which need 8k cache , but we don't want to cost so much ram to pass the verify part .
so liang change the nvs code which can avoid this problem . 
this is just a solution which will as a patch used in mass product , it will not merge into upstream , can you provide some suggestion or better solution .