### PR TITLE
soc: riscv: telink_b9x: MCUBoot platform extensions

### DIFF
--- a/scripts/west_commands/runners/bdt_tool.py
+++ b/scripts/west_commands/runners/bdt_tool.py
@@ -68,6 +68,11 @@ class BDTBinaryRunner(ZephyrBinaryRunner):
         activate = subprocess.Popen(['./bdt', soc_type, 'ac'], cwd=self.bdt_path)
         if activate.wait():
             exit()
+        # unlock flash only B92
+        if soc_type == 'B92':
+            unlock = subprocess.Popen(['./bdt', soc_type, 'ulf'], cwd=self.bdt_path)
+            if unlock.wait():
+                exit()
         # erase flash
         if self.erase:
             erase = subprocess.Popen(['./bdt', soc_type, 'wf', '0', '-e', '-s', flash_size], cwd=self.bdt_path)

--- a/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
@@ -43,3 +43,16 @@ zephyr_link_libraries(
 	-Wl,--wrap,sys_heap_aligned_alloc
 	-Wl,--wrap,sys_heap_aligned_realloc
 )
+
+# Make MCUBoot early boot code injection
+if (CONFIG_MCUBOOT)
+
+zephyr_sources(
+	mcu_boot_startup.c
+)
+
+zephyr_link_libraries(
+	-Wl,--wrap,main
+)
+
+endif()

--- a/soc/riscv/riscv-privilege/telink_b9x/mcu_boot_startup.c
+++ b/soc/riscv/riscv-privilege/telink_b9x/mcu_boot_startup.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <bootutil/bootutil_log.h>
+BOOT_LOG_MODULE_REGISTER(telink_b9x_mcuboot);
+
+static bool telink_b9x_mcu_boot_startup(void);
+
+void __wrap_main(void)
+{
+	if (telink_b9x_mcu_boot_startup()) {
+		extern void __real_main(void);
+
+		__real_main();
+	}
+}
+
+/* Vendor specific code during MCUBoot startup */
+bool telink_b9x_mcu_boot_startup(void)
+{
+	bool result = true; /* run MCUBoot main */
+
+	BOOT_LOG_INF("Telink B9x MCUBoot on early boot");
+
+	return result;
+}


### PR DESCRIPTION
Inject Telink code during MCUBoot starting.
The function
void telink_b9x_mcu_boot_startup(void)
is executed at starting MCUBoot firmware.
This provides a possibility to add vendor specific code into MCUBoot firmware during its starting without modification MCUBoot sources.