### PR TITLE
soc: riscv: telink_b9x: Add config to run MCUBoot vendor code

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b9x/CMakeLists.txt
@@ -45,7 +45,7 @@ zephyr_link_libraries(
 )
 
 # Make MCUBoot early boot code injection
-if (CONFIG_MCUBOOT)
+if (CONFIG_TELINK_B9X_MCUBOOT_STARTUP)
 
 zephyr_sources(
 	mcu_boot_startup.c

--- a/soc/riscv/riscv-privilege/telink_b9x/Kconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b9x/Kconfig.series
@@ -28,3 +28,10 @@ config SOC_SERIES_RISCV_TELINK_B9X_NON_RETENTION_RAM_CODE
 	help
 	  Place Telink B9x SoCs ram code in non-retention area
 	  and restore this are after each retention.
+
+config TELINK_B9X_MCUBOOT_STARTUP
+	bool "Telink B9x MCUBoot startup handler"
+	depends on SOC_SERIES_RISCV_TELINK_B9X && MCUBOOT
+	help
+	  Run Telink specific vendor code before MCUBoot
+	  main process


### PR DESCRIPTION
Config option TELINK_B9X_MCUBOOT_STARTUP executes Telink vendor specific at booting MCUBoot before main process. By default option is disabled.