### PR TITLE
telink: tl321x: update BLE lib, hal_telink and zephyr to v4.0.4.2

### DIFF
--- a/boards/riscv/tl321x/tl3218x-common.dtsi
+++ b/boards/riscv/tl321x/tl3218x-common.dtsi
@@ -100,7 +100,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <96000000>;
 };
 
 &ram_ilm {

--- a/soc/riscv/riscv-privilege/telink_tlx/soc.c
+++ b/soc/riscv/riscv-privilege/telink_tlx/soc.c
@@ -8,7 +8,7 @@
 #include <clock.h>
 #include <gpio.h>
 #include <ext_driver/ext_pm.h>
-
+#include "rf_common.h"
 #include "flash.h"
 #include <watchdog.h>
 #include <zephyr/kernel.h>
@@ -103,7 +103,7 @@ static int soc_b9x_init(void)
 #endif /* CONFIG_PM  */
 
 	/* system init */
-	sys_init(VBAT_TYPE, INTERNAL_CAP_XTAL24M);
+	sys_init(POWER_MODE, VBAT_TYPE, INTERNAL_CAP_XTAL24M);
 
 #if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
@@ -156,7 +156,7 @@ void soc_b9x_restore(void)
 	unsigned int cclk = DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency);
 
 	/* system init */
-	sys_init(VBAT_TYPE, INTERNAL_CAP_XTAL24M);
+	sys_init(POWER_MODE, VBAT_TYPE, INTERNAL_CAP_XTAL24M);
 
 #if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: a7ba6a116666f2150931d31179a1083487a5b6ab
+      revision: 478b9c07ccd9c974bb8e57ca4ca79b84abbebc28
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
update 
- sys_init parameter list in telink_tlx/soc.c.
- hal_telink and BLE lib.
according to BLE release tag v4.0.4.2