### PR TITLE
soc: riscv: telink_w91: Matter dual core OTA adoptation

### DIFF
--- a/boards/riscv/tlsr9118bdk40d/tlsr9118bdk40d-common.dtsi
+++ b/boards/riscv/tlsr9118bdk40d/tlsr9118bdk40d-common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Telink Semiconductor
+ * Copyright (c) 2024 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -83,23 +83,27 @@
 		};
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x20000 0x68000>;
+			reg = <0x20000 0x120000>;
 		};
-		slot1_partition: partition@88000 {
+		n22_partition: partition@140000 { // Don't change n22_partition
+			label = "image-n22";
+			reg = <0x140000 0xc7000>;
+		};
+		slot1_partition: partition@207000 {
 			label = "image-1";
-			reg = <0x88000 0x68000>;
+			reg = <0x207000 0x120000>;
 		};
-		scratch_partition: partition@f0000 {
+		scratch_partition: partition@327000 {
 			label = "image-scratch";
-			reg = <0xf0000 0x4000>;
+			reg = <0x327000 0x4000>;
 		};
-		storage_partition: partition@f4000 {
+		storage_partition: partition@32b000 {
 			label = "storage";
-			reg = <0xf4000 0xa000>;
+			reg = <0x32b000 0xa000>;
 		};
-		vendor_partition: partition@fe000 {
+		vendor_partition: partition@3fe000 {
 			label = "vendor-data";
-			reg = <0xfe000 0x2000>;
+			reg = <0x3fe000 0x2000>;
 		};
 	};
 };

--- a/dts/riscv/telink/telink_w91.dtsi
+++ b/dts/riscv/telink/telink_w91.dtsi
@@ -90,7 +90,7 @@
 
 			flash: flash@80000000 {
 				compatible = "soc-nv-flash";
-				reg = <0x80000000 0x300000>;
+				reg = <0x80000000 0x400000>;
 				write-block-size = <1>;
 			};
 		};

--- a/scripts/utils/telink_w91_post_build
+++ b/scripts/utils/telink_w91_post_build
@@ -1,70 +1,73 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2023 Telink Semiconductor
+# Copyright (c) 2024 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Download Telink N22 core firmware
+Download Telink N22 core firmware and optionally Matter MCUboot firmware
 ###############################################
 
-telink_w91_post_build <1> <2>
+telink_w91_post_build <1> <2> <3>
 
 1 - zephyr output binary folder
-2 - N22 core git revision
+2 - git revision
+3 - Matter OTA layout (1 if enabled, 0 if not)
 """
 
 import sys
 import os
 import requests
 
-N22_URL_FORMAT = f'https://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/w91_n22/w91_n22_%s.bin'
+BASE_URL = f'https://wiki.telink-semi.cn/wiki/protocols/Zephyr/binaries/public/w91_n22/'
+N22_URL_FORMAT = BASE_URL + f'w91_n22_%s.bin'
+MATTER_MCUBOOT_URL_FORMAT = BASE_URL + f'w91_mcuboot_%s.bin'
+
+def download_file(url, destination):
+	print(f'fetching {url}...')
+	try:
+		response = requests.get(url)
+		if response.status_code != 200:
+			print(f'error: Can\'t fetch {url}.')
+			return False
+	except Exception as e:
+		print(f'error: Can\'t fetch {url}: {str(e)}')
+		return False
+
+	try:
+		with open(destination, 'wb') as f:
+			f.write(response.content)
+		print(f'saved {destination}')
+		return True
+	except Exception as e:
+		print(f'error: Can\'t save {destination}: {str(e)}')
+		return False
 
 def main():
-	bin_path = None
-	try:
-		bin_path = sys.argv[1]
-	except:
-		pass
-
-	n22_revision = None
-	try:
-		n22_revision = sys.argv[2]
-	except:
-		pass
-
-	if bin_path is None or n22_revision is None:
+	if len(sys.argv) < 3:
 		print('error: Invalid arguments.')
 		return
+
+	bin_path = sys.argv[1]
+	n22_revision = sys.argv[2]
+	matter_ota_layout_enabled = sys.argv[3] if len(sys.argv) > 3 else '0'
 
 	if not os.path.exists(bin_path) or not os.path.isdir(bin_path):
 		print(f'error: Invalid binary path \'{bin_path}\'.')
 		return
 
+	# Download N22 core firmware
 	n22_bin_url = N22_URL_FORMAT % n22_revision
-	print('fetching %s ...' % n22_bin_url)
-
-	try:
-		response = requests.get(n22_bin_url)
-	except:
-		print(f'error: Can\'t fetch.')
-		return
-
-	if response.status_code != 200:
-		print(f'error: Can\'t fetch.')
-		return
-
 	n22_bin_name = os.path.join(bin_path, 'n22.bin')
-
-	try:
-		n22_bin = open(n22_bin_name, 'w+b');
-	except:
-		print(f'error: Can\'t create file \'{n22_bin_name}\'.')
+	if not download_file(n22_bin_url, n22_bin_name):
 		return
 
-	n22_bin.write(response.content)
-	n22_bin.close()
-	print(f'saved N22 firmware into \'{n22_bin_name}\'')
+	# Download Matter MCUboot firmware if Matter OTA layout is enabled
+	if matter_ota_layout_enabled == '1':
+		matter_mcuboot_url = MATTER_MCUBOOT_URL_FORMAT % n22_revision
+		matter_mcuboot_name = os.path.join(bin_path, 'mcuboot.bin')
+		if not download_file(matter_mcuboot_url, matter_mcuboot_name):
+			return
 
 if __name__ == "__main__":
 	main()

--- a/scripts/west_commands/runners/sctool.py
+++ b/scripts/west_commands/runners/sctool.py
@@ -10,10 +10,13 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
 class SCTOOLBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for Senscomm Flash Tool.'''
 
+    SERIAL_BAUDE_RATE = '2000000'
+
     def __init__(self, cfg, sctool_path, usb_port, address, erase=False, update_n22=False):
         super().__init__(cfg)
         self.sctool_path = sctool_path
         self.usb_port = usb_port
+        self.baude_rate = self.SERIAL_BAUDE_RATE
         self.address = address
         self.erase = bool(erase)
         self.update_n22 = bool(update_n22)
@@ -32,7 +35,7 @@ class SCTOOLBinaryRunner(ZephyrBinaryRunner):
             help='path to sctool installation root')
         parser.add_argument('--usb-port', default='/dev/ttyUSB0',
             help='USB CDC to which device is attached')
-        parser.add_argument('--address', default='0x80000000',
+        parser.add_argument('--address', default=None,
             help='start flash address to write')
         parser.add_argument("--update-n22", action="store_true",
             help="upadet N22 FW")
@@ -59,22 +62,42 @@ class SCTOOLBinaryRunner(ZephyrBinaryRunner):
         if not build_conf['CONFIG_SOC_RISCV_TELINK_W91']:
             print('only Telink W91 chip is supported!')
             exit()
-        # download RAM
-        pre_erase = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '--before', 'hw_reset', '--after', 'no_reset', '-b', '115200', 'upload_da'], cwd=self.sctool_path)
-        if pre_erase.wait():
-            exit()
         # get flash size
         flash_size = hex(build_conf['CONFIG_FLASH_SIZE'] * 1024)
+        # get flash base address
+        if self.address is not None: # if user defined use it
+            print(f'User defined flash base address: {self.address}')
+            flash_base = self.address
+        else:
+            # calculate flash base address from configuration
+            if build_conf.getboolean('CONFIG_MCUBOOT'): # mcuboot
+                print('MCUboot app!')
+                flash_base = hex(build_conf['CONFIG_FLASH_BASE_ADDRESS'])
+            elif build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'): # MCU boot app
+                print('MCUboot bootloader app!')
+                flash_base = hex(build_conf['CONFIG_FLASH_BASE_ADDRESS'] +
+                                 build_conf['CONFIG_FLASH_LOAD_OFFSET'])
+            else: # standalone app
+                print('Standalone app!')
+                flash_base = hex(build_conf['CONFIG_FLASH_BASE_ADDRESS'])
+        # get N22 partition address
+        n22_partition_addr = hex(build_conf['CONFIG_TELINK_W91_N22_PARTITION_ADDR'] + int(flash_base, 16))
+        # download RAM
+        pre_erase = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '-b', self.baude_rate, '--before', 'hw_reset', '--after', 'no_reset', 'upload_da'], cwd=self.sctool_path)
+        if pre_erase.wait():
+            exit()
         print('Flashing D25 FW...')
-        # erase flash
+        # erase flash if needed
         if self.erase:
-            erase = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '-b', '115200', '--manual', 'flash_erase', '0x80000000', flash_size], cwd=self.sctool_path)
+            print('Erasing flash...')
+            flash_base_erase = hex(build_conf['CONFIG_FLASH_BASE_ADDRESS'])
+            erase = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '--manual', 'flash_erase', flash_base_erase, flash_size], cwd=self.sctool_path)
             if erase.wait():
                 exit()
         # get binary file
         bin_file = os.path.abspath(self.cfg.bin_file)
         # flash
-        flash = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '--after', 'hw_reset', '-b', '115200', '--manual', 'flash_write', self.address, bin_file], cwd=self.sctool_path)
+        flash = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '--after', 'hw_reset', '--manual', 'flash_write', flash_base, bin_file], cwd=self.sctool_path)
         if flash.wait():
             exit()
         print('D25 FW done!')
@@ -86,12 +109,8 @@ class SCTOOLBinaryRunner(ZephyrBinaryRunner):
             if not os.path.isfile(n22_fw_bin):
                 print(f'N22 FW not exist {n22_fw_bin}')
                 exit()
-            # erase N22 area
-            erase = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '-b', '115200', '--manual', 'flash_erase', '0x80300000', '0x100000'], cwd=self.sctool_path)
-            if erase.wait():
-                exit()
             # flash N22 FW
-            flash = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '--after', 'hw_reset', '-b', '115200', '--manual', 'flash_write', '0x80300000', n22_fw_bin], cwd=self.sctool_path)
+            flash = subprocess.Popen(['./sctool', '-p', self.usb_port, '-da', 'da/da.ram.bin', '--after', 'hw_reset', '--manual', 'flash_write', n22_partition_addr, n22_fw_bin], cwd=self.sctool_path)
             if flash.wait():
                 exit()
             print('N22 FW done!')

--- a/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Telink Semiconductor
+# Copyright (c) 2024 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
 if (CONFIG_TELINK_W91_2_WIRE_SPI_ENABLE)
@@ -91,5 +91,6 @@ endif()
 if(CONFIG_TELINK_W91_FETCH_N22_BIN)
 	set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
 		${ZEPHYR_BASE}/scripts/utils/telink_w91_post_build ${ZEPHYR_BINARY_DIR} ${CONFIG_TELINK_W91_FETCH_N22_BIN_REVISION}
+		$<IF:$<BOOL:${CONFIG_TELINK_W91_N22_MATTER_OTA_LAYOUT}>,1,0>
 	)
 endif()

--- a/soc/riscv/riscv-privilege/telink_w91/Kconfig.n22
+++ b/soc/riscv/riscv-privilege/telink_w91/Kconfig.n22
@@ -1,5 +1,12 @@
-# Copyright (c) 2023 Telink Semiconductor
+# Copyright (c) 2024 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
+
+config TELINK_W91_N22_HART
+	int "N22 HART ID"
+	default 1
+	depends on SOC_SERIES_RISCV_TELINK_W91
+	help
+		This option sets N22 HART ID.
 
 config TELINK_W91_FETCH_N22_BIN
 	bool "Fetch N22 binary after build"
@@ -10,7 +17,18 @@ config TELINK_W91_FETCH_N22_BIN
 
 config TELINK_W91_FETCH_N22_BIN_REVISION
 	string "N22 binaries revision"
-	default "24a60e998dc4ab986c147bcf2c910ba458198fab"
+	default "6dbeefe1356aa444f76b4f12a21d426019675e07"
 	depends on TELINK_W91_FETCH_N22_BIN
 	help
 		This option sets N22 binary revision.
+
+config TELINK_W91_N22_PARTITION_ADDR
+	hex "N22 partition address"
+	default $(dt_node_reg_addr_hex,$(dt_nodelabel_path,n22_partition),0)
+
+config TELINK_W91_N22_MATTER_OTA_LAYOUT
+	bool "Support Matter dual core OTA"
+	depends on TELINK_W91_FETCH_N22_BIN
+	default n
+	help
+		This option enables support Matter dual core OTA

--- a/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
+++ b/soc/riscv/riscv-privilege/telink_w91/core_heartbeat/Kconfig.heartbeat
@@ -3,6 +3,7 @@
 
 config TELINK_W91_CORE_HEARTBEAT
 	bool "Telink W91 intercore heartbeat"
+	depends on SOC_SERIES_RISCV_TELINK_W91
 	default y
 	help
 		This option enables Telink W91 heartbeat messages between cores.

--- a/soc/riscv/riscv-privilege/telink_w91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_w91/linker.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Telink Semiconductor
+ * Copyright (c) 2024 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,4 +23,6 @@ MEMORY
 
 #ifdef CONFIG_MCUBOOT
 	ASSERT(__rom_region_size <= DT_REG_SIZE(DT_NODELABEL(boot_partition)), "boot_partition overflows")
+#else
+	ASSERT(__rom_region_end < (CONFIG_FLASH_BASE_ADDRESS + CONFIG_TELINK_W91_N22_PARTITION_ADDR), "n22_partition overlaps")
 #endif

--- a/soc/riscv/riscv-privilege/telink_w91/soc.c
+++ b/soc/riscv/riscv-privilege/telink_w91/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Telink Semiconductor
+ * Copyright (c) 2024 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,10 +14,6 @@
 #if (DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency) != CLK_160MHZ)
 	#error "Unsupported clock-frequency. Supported values: 160 MHz"
 #endif
-
-#define SYS_BASE                          0xf1700000
-#define SYS_CORE_RESET_CTRL               0x218
-#define __write_reg32(addr, value)        (*(volatile uint32_t *)(addr) = (uint32_t)(value))
 
 /**
  * @brief Perform basic initialization at boot.
@@ -38,7 +34,8 @@ void sys_arch_reboot(int type)
 {
 	ARG_UNUSED(type);
 
-	__write_reg32(SYS_BASE + SYS_CORE_RESET_CTRL, 1 << (csr_read(mhartid) * 4));
+	sys_write32(D25_START_ADDR, D25_RESET_VECTOR);
+	sys_write32(D25_MASK, HART_RESET_CTRL);
 }
 
 SYS_INIT(soc_w91_init, PRE_KERNEL_1, 0);

--- a/soc/riscv/riscv-privilege/telink_w91/soc.h
+++ b/soc/riscv/riscv-privilege/telink_w91/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Telink Semiconductor
+ * Copyright (c) 2024 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,8 +9,19 @@
 
 #include <soc_common.h>
 
-#define NDS_MXSTATUS                0x7c4
-#define NDS_MCACHE_CTL              0x7ca
-#define NDS_MMISC_CTL               0x7d0
+#define NDS_MXSTATUS            0x7c4
+#define NDS_MCACHE_CTL          0x7ca
+#define NDS_MMISC_CTL           0x7d0
+
+#define D25_RESET_VECTOR        0xf0100200
+#define N22_RESET_VECTOR        0xf0100204
+#define HART_RESET_CTRL         0xf1700218
+
+#define D25_START_OFFSET        0xa0
+#define D25_START_ADDR          (CONFIG_FLASH_BASE_ADDRESS + D25_START_OFFSET)
+#define N22_START_ADDR          (CONFIG_FLASH_BASE_ADDRESS + CONFIG_TELINK_W91_N22_PARTITION_ADDR)
+
+#define D25_MASK                (1 << (CONFIG_RV_BOOT_HART * 4))
+#define N22_MASK                (1 << (CONFIG_TELINK_W91_N22_HART * 4))
 
 #endif /* RISCV_TELINK_W91_SOC_H */

--- a/soc/riscv/riscv-privilege/telink_w91/start.S
+++ b/soc/riscv/riscv-privilege/telink_w91/start.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Telink Semiconductor
+ * Copyright (c) 2024 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,9 +9,8 @@
 
 #include "soc.h"
 
-#define N22_CORE_START (DT_REG_ADDR(DT_CHOSEN(zephyr_flash)) + DT_REG_SIZE(DT_CHOSEN(zephyr_flash)))
-#define IPC_REMOTE_TX_START (DT_REG_ADDR(DT_N_NODELABEL_sram_rx))
-#define IPC_REMOTE_TX_END (IPC_REMOTE_TX_START + DT_REG_SIZE(DT_N_NODELABEL_sram_rx))
+#define IPC_REMOTE_TX_START (DT_REG_ADDR(DT_NODELABEL(sram_rx)))
+#define IPC_REMOTE_TX_END (IPC_REMOTE_TX_START + DT_REG_SIZE(DT_NODELABEL(sram_rx)))
 
 	.option push
 	.option norelax
@@ -22,19 +21,36 @@ SECTION_FUNC(init, init)
 	.global reset_vector
 
 reset_vector:
-	.global _start
-	.type _start,@function
+	.global _check_start_core
+	.type _check_start_core,@function
 
 #if !defined(CONFIG_BOOTLOADER_MCUBOOT)
-	.word (0x31707848)                 #/ magic
-	.word (0x33e90d91)                 #/ header crc32
+	.word (0x31707848)                      #/ magic
+	.word (0x33e90d91)                      #/ header crc32
 	.org 0x14
-	.word (0xa0000080)                 #/ start address
+	.word (((D25_START_ADDR >> 24) & 0xff)   | \
+	       ((D25_START_ADDR >> 8)  & 0xff00) | \
+	       ((D25_START_ADDR & 0xff00) << 8)  | \
+	       ((D25_START_ADDR & 0xff) << 24)) #/ start address
 
-	.org 0xa0
+	.org D25_START_OFFSET
 #endif
 
-_start:                                #/ after reset starts on D25 core
+_check_start_core:
+
+	csrr a0, mhartid
+	li t0, CONFIG_RV_BOOT_HART
+	beq a0, t0, _start                      #/ started on D25 core
+
+	lui    t0, %hi(D25_RESET_VECTOR)        #/ started on N22 core, change into D25 core
+	lui    t1, %hi(_start)
+	addi   t1, t1, %lo(_start)
+	sw     t1, %lo(D25_RESET_VECTOR)(t0)    #/ D25 core addr: D25_RESET_VECTOR <- _start
+	lui    t0, %hi(HART_RESET_CTRL)
+	li     t1, D25_MASK
+	sw     t1, %lo(HART_RESET_CTRL)(t0)     #/ D25 core reset: HART_RESET_CTRL <- D25_MASK
+
+_start:                                     #/ after reset starts on D25 core
 
 	lui    t0, 0
 	la     t2, IPC_REMOTE_TX_START
@@ -47,41 +63,41 @@ _ZERO_IPC_REMOTE_TX_BEGIN:
 
 _start_n22:
 
-	lui    t0, 0xf0100
-	lui    t1, %hi(N22_CORE_START)
-	addi   t1, t1, %lo(N22_CORE_START)
-	sw     t1, 0x204(t0)               #/ N22 core address: 0xf0100204 <- N22_CORE_START
-	lui    t0, 0xf1700
-	li     t1, 0x10
-	sw     t1, 0x218(t0)               #/ N22 core reset: 0xf1700218 <- 0x10
+	lui    t0, %hi(N22_RESET_VECTOR)
+	lui    t1, %hi(N22_START_ADDR)
+	addi   t1, t1, %lo(N22_START_ADDR)
+	sw     t1, %lo(N22_RESET_VECTOR)(t0)    #/ N22 core addr: N22_RESET_VECTOR <- N22_START_ADDR
+	lui    t0, %hi(HART_RESET_CTRL)
+	li     t1, N22_MASK
+	sw     t1, %lo(HART_RESET_CTRL)(t0)     #/ N22 core reset: HART_RESET_CTRL <- N22_MASK
 
-	csrw   mie, zero                   #/ disable interrupts
+	csrw   mie, zero                        #/ disable interrupts
 	li     t0, (1 << 3)
-	csrc   mstatus, t0                 #/ Clear Machine Status
-	csrw   mepc, zero                  #/ Clear Machine Exception PC
+	csrc   mstatus, t0                      #/ Clear Machine Status
+	csrw   mepc, zero                       #/ Clear Machine Exception PC
 	li     t0, (3 << 6)
-	csrc   NDS_MXSTATUS, t0            #/ Clear Machine Extended Status
+	csrc   NDS_MXSTATUS, t0                 #/ Clear Machine Extended Status
 
 #if defined(CONFIG_TELINK_W91_2_WIRE_SPI_ENABLE) && CONFIG_TELINK_W91_2_WIRE_SPI_ENABLE
 	lui    t0, 0xf0900
 	li     t1, 0x00
-	sw     t1, 0x050(t0)               #/ SPI flash regular mode: 0xf0900050 <- 0x00
+	sw     t1, 0x050(t0)                    #/ SPI flash regular mode: 0xf0900050 <- 0x00
 #else
 	lui    t0, 0xf0900
 	li     t1, 0x05
-	sw     t1, 0x050(t0)               #/ SPI flash quad mode: 0xf0900050 <- 0x05
+	sw     t1, 0x050(t0)                    #/ SPI flash quad mode: 0xf0900050 <- 0x05
 #endif
 
 #if defined(CONFIG_ICACHE) && CONFIG_ICACHE
 	li     t0, 0x1
-	csrs   NDS_MCACHE_CTL, t0          #/ enable I-Cache
+	csrs   NDS_MCACHE_CTL, t0               #/ enable I-Cache
 #endif
 #if defined(CONFIG_DCACHE) && CONFIG_DCACHE
 	li     t0, 0x2
-	csrs   NDS_MCACHE_CTL, t0          #/ enable D-Cache
+	csrs   NDS_MCACHE_CTL, t0               #/ enable D-Cache
 #endif
 	li     t0, (1 << 6)
-	csrs   NDS_MMISC_CTL, t0           #/ Enable Misaligned access
+	csrs   NDS_MMISC_CTL, t0                #/ Enable Misaligned access
 
 _RAM_DLM_INIT:
 	la     t1, _RAM_DLM_LMA_START
@@ -108,7 +124,7 @@ _RAM_CODE_INIT_BEGIN:
 	j      _RAM_CODE_INIT_BEGIN
 
 _START:
-	call   __start                     #/ jump to kernel entry
+	call   __start                          #/ jump to kernel entry
 1:	j      1b
 
 	.option pop


### PR DESCRIPTION
- change N22 Image offset & size for Matter OTA
- add check of n22_partition overlaps
- download optionally Matter MCUboot files
- use 4m flash as default
- add check start core with switch
- use offset and size from DTS for sctool
- set correct reset vector & more optimizations
- updated N22 binary revision