### PR TITLE
telink: Fix CI for b9x platform

### DIFF
--- a/boards/telink/tlsr9258a/Kconfig.tlsr9258a
+++ b/boards/telink/tlsr9258a/Kconfig.tlsr9258a
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_TLSR9258A

--- a/boards/telink/tlsr9258a/Kconfig.tlsr9258a_retention
+++ b/boards/telink/tlsr9258a/Kconfig.tlsr9258a_retention
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_TLSR9258A_RETENTION

--- a/boards/telink/tlsr9518adk80d/Kconfig.tlsr9518adk80d
+++ b/boards/telink/tlsr9518adk80d/Kconfig.tlsr9518adk80d
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_TLSR9518ADK80D

--- a/boards/telink/tlsr9518adk80d/Kconfig.tlsr9518adk80d_retention
+++ b/boards/telink/tlsr9518adk80d/Kconfig.tlsr9518adk80d_retention
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_TLSR9518ADK80D_RETENTION

--- a/boards/telink/tlsr9528a/Kconfig.tlsr9528a
+++ b/boards/telink/tlsr9528a/Kconfig.tlsr9528a
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_TLSR9528A

--- a/boards/telink/tlsr9528a/Kconfig.tlsr9528a_retention
+++ b/boards/telink/tlsr9528a/Kconfig.tlsr9528a_retention
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_TLSR9528A_RETENTION

--- a/drivers/bluetooth/hci/hci_b9x.c
+++ b/drivers/bluetooth/hci/hci_b9x.c
@@ -28,7 +28,7 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 	uint8_t evt_type = evt_data[0];
 
 	switch (evt_type) {
-#if defined(CONFIG_BT_BREDR)
+#if defined(CONFIG_BT_CLASSIC)
 	case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
 	case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
 		return true;

--- a/drivers/gpio/gpio_b9x.c
+++ b/drivers/gpio/gpio_b9x.c
@@ -31,18 +31,19 @@
 #define DT_DRV_COMPAT telink_b9x_gpio
 
 /* Get GPIO instance */
-#define GET_GPIO(dev)           ((volatile struct gpio_b9x_t *)	\
-				 ((const struct gpio_b9x_config *)dev->config)->gpio_base)
+#define GET_GPIO(dev)                                                                              \
+	((volatile struct gpio_b9x_t *)((const struct gpio_b9x_config *)dev->config)->gpio_base)
 
 /* Get GPIO IRQ number defined in dts */
-#define GET_IRQ_NUM(dev)        (irq_from_level_2(((const struct gpio_b9x_config *)dev->config)->irq_num))
+#define GET_IRQ_NUM(dev) (irq_from_level_2(((const struct gpio_b9x_config *)dev->config)->irq_num))
 
 /* Get GPIO IRQ priority defined in dts */
 #define GET_IRQ_PRIORITY(dev)   (((const struct gpio_b9x_config *)dev->config)->irq_priority)
 
 /* Get GPIO port number: port A - 0, port B - 1, ..., port F - 5  */
-#define GET_PORT_NUM(gpio)      ((uint8_t)(((uint32_t)gpio - DT_REG_ADDR(DT_NODELABEL(gpioa))) / \
-					   DT_REG_SIZE(DT_NODELABEL(gpioa))))
+#define GET_PORT_NUM(gpio)                                                                         \
+	((uint8_t)(((uint32_t)gpio - DT_REG_ADDR(DT_NODELABEL(gpioa))) /                           \
+		   DT_REG_SIZE(DT_NODELABEL(gpioa))))
 
 /* Check that gpio is port C */
 #define IS_PORT_C(gpio)         ((uint32_t)gpio == DT_REG_ADDR(DT_NODELABEL(gpioc)))
@@ -891,27 +892,20 @@ PM_DEVICE_DT_INST_DEFINE(n, gpio_b9x_pm_action);
 
 
 /* GPIO driver registration */
-#define GPIO_B9X_INIT(n)						    \
-	PM_DEVICE_INST_DEFINE(n, gpio_b9x_pm_action)	\
-	static struct gpio_b9x_pin_irq_config gpio_b9x_pin_irq_state_##n; \
-	static const struct gpio_b9x_config gpio_b9x_config_##n = {	    \
-		.common = {						    \
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n) \
-		},							    \
-		.gpio_base = DT_INST_REG_ADDR(n),			    \
-		.irq_num = DT_INST_IRQN(n),				    \
-		.irq_priority = DT_INST_IRQ(n, priority),		    \
-		.pin_irq_state = &gpio_b9x_pin_irq_state_##n,	\
-		.pirq_connect = gpio_b9x_irq_connect_##n		    \
-	};								    \
-	static struct gpio_b9x_data gpio_b9x_data_##n;			    \
-									    \
-	DEVICE_DT_INST_DEFINE(n, gpio_b9x_init,				    \
-			      PM_DEVICE_INST_GET(n),					    \
-			      &gpio_b9x_data_##n,			    \
-			      &gpio_b9x_config_##n,			    \
-			      PRE_KERNEL_1,				    \
-			      CONFIG_GPIO_INIT_PRIORITY,		    \
+#define GPIO_B9X_INIT(n)                                                                           \
+	PM_DEVICE_INST_DEFINE(n, gpio_b9x_pm_action)                                               \
+	static struct gpio_b9x_pin_irq_config gpio_b9x_pin_irq_state_##n;                          \
+	static const struct gpio_b9x_config gpio_b9x_config_##n = {                                \
+		.common = {.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n)},                   \
+		.gpio_base = DT_INST_REG_ADDR(n),                                                  \
+		.irq_num = DT_INST_IRQN(n),                                                        \
+		.irq_priority = DT_INST_IRQ(n, priority),                                          \
+		.pin_irq_state = &gpio_b9x_pin_irq_state_##n,                                      \
+		.pirq_connect = gpio_b9x_irq_connect_##n};                                         \
+	static struct gpio_b9x_data gpio_b9x_data_##n;                                             \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, gpio_b9x_init, PM_DEVICE_INST_GET(n), &gpio_b9x_data_##n,         \
+			      &gpio_b9x_config_##n, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,       \
 			      &gpio_b9x_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(GPIO_B9X_INIT)
+DT_INST_FOREACH_STATUS_OKAY(GPIO_B9X_INIT);

--- a/drivers/usb/device/usb_dc_b9x.c
+++ b/drivers/usb/device/usb_dc_b9x.c
@@ -847,7 +847,8 @@ static int usb_irq_init(void)
 	riscv_plic_irq_enable(USBD_B9X_IRQN_BY_IDX(4));
 	riscv_plic_set_priority(USBD_B9X_IRQN_BY_IDX(4), USBD_B9X_IRQ_PRIORITY_BY_IDX(4));
 
-	IRQ_CONNECT(USBD_B9X_IRQN_BY_IDX(5), USBD_B9X_IRQ_PRIORITY_BY_IDX(5), usb_irq_suspend, 0, 0);
+	IRQ_CONNECT(USBD_B9X_IRQN_BY_IDX(5), USBD_B9X_IRQ_PRIORITY_BY_IDX(5), usb_irq_suspend, 0,
+		    0);
 	riscv_plic_irq_enable(USBD_B9X_IRQN_BY_IDX(5));
 	riscv_plic_set_priority(USBD_B9X_IRQN_BY_IDX(5), USBD_B9X_IRQ_PRIORITY_BY_IDX(5));
 

--- a/dts/bindings/pinctrl/telink,b9x-pinctrl.yaml
+++ b/dts/bindings/pinctrl/telink,b9x-pinctrl.yaml
@@ -83,7 +83,7 @@ properties:
 
 child-binding:
   description: |
-      This binding gives a base representation of the Telink B91 pins configration.
+      This binding gives a base representation of the Telink B91 pins configuration.
 
   include:
   - name: pincfg-node.yaml

--- a/samples/net/openthread/cli/boards/tlsr9258a.overlay
+++ b/samples/net/openthread/cli/boards/tlsr9258a.overlay
@@ -13,5 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
- 	};
+	};
 };

--- a/samples/net/openthread/coprocessor/boards/tlsr9258a.overlay
+++ b/samples/net/openthread/coprocessor/boards/tlsr9258a.overlay
@@ -14,7 +14,8 @@
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart1_tx_pc6_default &uart1_rx_pc7_default &uart1_rts_pc5_default &uart1_cts_pc4_default>;
+	pinctrl-0 = <&uart1_tx_pc6_default &uart1_rx_pc7_default
+					&uart1_rts_pc5_default &uart1_cts_pc4_default>;
 	pinctrl-names = "default";
 	hw-flow-control;
 };

--- a/samples/net/openthread/coprocessor/boards/tlsr9518adk80d.overlay
+++ b/samples/net/openthread/coprocessor/boards/tlsr9518adk80d.overlay
@@ -14,7 +14,8 @@
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart1_tx_pc6_default &uart1_rx_pc7_default &uart1_rts_pc5_default &uart1_cts_pc4_default>;
+	pinctrl-0 = <&uart1_tx_pc6_default &uart1_rx_pc7_default
+					&uart1_rts_pc5_default &uart1_cts_pc4_default>;
 	pinctrl-names = "default";
 	hw-flow-control;
 };

--- a/samples/net/openthread/coprocessor/boards/tlsr9528a.overlay
+++ b/samples/net/openthread/coprocessor/boards/tlsr9528a.overlay
@@ -14,7 +14,8 @@
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart1_tx_pc6_default &uart1_rx_pc7_default &uart1_rts_pc5_default &uart1_cts_pc4_default>;
+	pinctrl-0 = <&uart1_tx_pc6_default &uart1_rx_pc7_default
+					&uart1_rts_pc5_default &uart1_cts_pc4_default>;
 	pinctrl-names = "default";
 	hw-flow-control;
 };

--- a/soc/telink/tlsr/telink_b9x/soc.c
+++ b/soc/telink/tlsr/telink_b9x/soc.c
@@ -397,19 +397,17 @@ static int soc_b9x_check_flash(void)
 	static const size_t dts_flash_size = DT_REG_SIZE(DT_CHOSEN(zephyr_flash));
 	size_t hw_flash_size = 0;
 	unsigned int  mid = flash_read_mid();
-	const flash_capacity_e hw_flash_cap =
-		(mid & FLASH_MID_SIZE_MASK) >> FLASH_MID_SIZE_OFFSET;
+
+	const flash_capacity_e hw_flash_cap = (mid & FLASH_MID_SIZE_MASK) >> FLASH_MID_SIZE_OFFSET;
 
 #if CONFIG_SOC_RISCV_TELINK_B92
 	/* Enable 4x SPI read and write */
-
 	if (flash_set_4line_read_write(mid) != 1) {
 
 	}
 
 #elif CONFIG_SOC_RISCV_TELINK_B95
 	/* Enable 4x SPI read and write */
-
 	if (flash_set_4line_read_write(SLAVE0, mid) != 1) {
 
 	}

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -53,7 +53,7 @@ config BT_HCI_TX_STACK_SIZE
 	default 768 if BT_CTLR && BT_LL_SW_SPLIT
 	default 512 if BT_USERCHAN
 	default 640 if BT_STM32_IPM
-	default 1024 if BT_B91
+	default 1024 if BT_B9X
 	# Even if no driver is selected the following default is still
 	# needed e.g. for unit tests. This default will also server as
 	# the worst-case stack size if an out-of-tree controller is used.

--- a/subsys/net/CMakeLists.txt
+++ b/subsys/net/CMakeLists.txt
@@ -19,3 +19,5 @@ add_subdirectory(lib)
 if(CONFIG_NET_CONNECTION_MANAGER)
   add_subdirectory(conn_mgr)
 endif()
+
+zephyr_library_property(ALLOW_EMPTY TRUE)


### PR DESCRIPTION
Fix style warnings:
- C code formatting
- Add boards configs
- Fix removed Kconfigs