### PR TITLE
soc: telink: Increase SYSTEM_WORKQUEUE_STACK_SIZE

### DIFF
--- a/soc/telink/tlsr/telink_b9x/Kconfig.defconfig
+++ b/soc/telink/tlsr/telink_b9x/Kconfig.defconfig
@@ -46,6 +46,10 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	default 1536
 
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	int
+	default 2048
+
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	default 2048
 

--- a/soc/telink/tlsr/telink_w9x/Kconfig.defconfig
+++ b/soc/telink/tlsr/telink_w9x/Kconfig.defconfig
@@ -59,6 +59,10 @@ config IDLE_STACK_SIZE
 	int
 	default 1536
 
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	int
+	default 2048
+
 config TEST_EXTRA_STACK_SIZE
 	int
 	default 1024


### PR DESCRIPTION
Increased SYSTEM_WORKQUEUE_STACK_SIZE since BLE controller is running with this context.