### PR TITLE
drivers: pinctrl: pinctrl_b9x.c: Fix pwm fault pulse

### DIFF
--- a/drivers/pinctrl/pinctrl_b9x.c
+++ b/drivers/pinctrl/pinctrl_b9x.c
@@ -254,9 +254,6 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 	uint32_t pin = B9x_PINMUX_GET_PIN(*pinctrl);
 	uint8_t pull_up_en_addr = reg_pull_up_en(pin);
 
-	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
-	pinctrl_b9x_gpio_function_disable(pin);
-
 	/* calculate offset and mask for the func and pull values */
 	status = pinctrl_b9x_get_offset(pin, &offset);
 	if (status != 0) {
@@ -274,6 +271,9 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 #elif CONFIG_SOC_RISCV_TELINK_B95
 	reg_pin_mux(pin) = (reg_pin_mux(pin) & (~B95_PIN_FUNC_POS)) | (func & B95_PIN_FUNC_POS);
 #endif
+
+	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
+	pinctrl_b9x_gpio_function_disable(pin);
 
 	/* set pull value */
 	pull = pull << offset;


### PR DESCRIPTION
- Adjust the execution position of gpio function disable.