### PR TITLE
telink: tl721x: build ble sample

### DIFF
--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Build TL721x samples/basic/button
       run: |
         cd ..
-        west build -b tl7218x     -d build_button_tl721x                      zephyr/samples/basic/button                          -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+        west build -b tl7218x                  -d build_button_tl721x                     zephyr/samples/basic/button                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
     - name: Build TL721X basic/blinky_pwm
       run: |
@@ -68,17 +68,17 @@ jobs:
     - name: Build TL721X tests/drivers/hwinfo/api
       run: |
         cd ..
-        west build -b tl7218x -d build_hwinfo_tl721x zephyr/tests/drivers/hwinfo/api
+        west build -b tl7218x                  -d build_hwinfo_tl721x                     zephyr/tests/drivers/hwinfo/api                          -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
     # - name: Build TL721X sensor/sht3xd
     #   run: |
     #     cd ..
     #     west build -b tl7218x                  -d build_sht3xd_tl721x                    zephyr/samples/sensor/sht3xd                             -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
-    # - name: Build TL721X bluetooth/peripheral_ht
-    #   run: |
-    #     cd ..
-    #     west build -b tl7218x                  -d build_peripheral_ht_tl721x             zephyr/samples/bluetooth/peripheral_ht                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+    - name: Build TL721X bluetooth/peripheral_ht
+      run: |
+        cd ..
+        west build -b tl7218x                  -d build_peripheral_ht_tl721x             zephyr/samples/bluetooth/peripheral_ht                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
     # - name: Build TL721X net/openthread/cli
     #   run: |
@@ -119,6 +119,7 @@ jobs:
         cp ../build_button_tl721x/zephyr/zephyr.bin                    telink_build_artifacts/tl721x_button.bin
         cp ../build_watchdog_tl721x/zephyr/zephyr.bin                  telink_build_artifacts/tl721x_watchdog.bin
         cp ../build_hwinfo_tl721x/zephyr/zephyr.bin                    telink_build_artifacts/tl721x_hwinfo.bin
+        cp ../build_peripheral_ht_tl721x/zephyr/zephyr.bin             telink_build_artifacts/tl721x_peripheral_ht.bin
         cp ../modules/hal/telink/zephyr/blobs/lib_zephyr_tl721x.a      telink_build_artifacts/lib_zephyr_tl721x.a
 
     - name: Publish artifacts

--- a/soc/riscv/riscv-privilege/telink_tlx/soc.c
+++ b/soc/riscv/riscv-privilege/telink_tlx/soc.c
@@ -98,16 +98,14 @@ _attribute_data_retention_sec_ struct {
  */
 void soc_load_rf_parameters_normal(void)
 {
-	if (!blt_miscParam.ext_cap_en) {
-		unsigned char cap_freq_ofset;
+	unsigned char cap_freq_ofset;
 
-		flash_read_page(FIXED_PARTITION_OFFSET(vendor_partition) +
-		TLX_CALIBRATION_ADDR_OFFSET, 1, &cap_freq_ofset);
-		if (cap_freq_ofset != 0xff) {
-			soc_nvParam.cap_freq_offset_en = 1;
-			soc_nvParam.cap_freq_offset_value = cap_freq_ofset;
-			rf_update_internal_cap(soc_nvParam.cap_freq_offset_value);
-		}
+	flash_read_page(FIXED_PARTITION_OFFSET(vendor_partition) +
+	TLX_CALIBRATION_ADDR_OFFSET, 1, &cap_freq_ofset);
+	if (cap_freq_ofset != 0xff) {
+		soc_nvParam.cap_freq_offset_en = 1;
+		soc_nvParam.cap_freq_offset_value = cap_freq_ofset;
+		rf_update_internal_cap(soc_nvParam.cap_freq_offset_value);
 	}
 }
 


### PR DESCRIPTION
- remove ext_cap_en according to ext_pm.h because the RF calibration should be performed with both internal and external crystal capacitors.