### PR TITLE
telink: tl721x: update adc driver for Tercel A1

### DIFF
--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -80,6 +80,11 @@ jobs:
         cd ..
         west build -b tl7218x                  -d build_peripheral_ht_tl721x             zephyr/samples/bluetooth/peripheral_ht                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
+    - name: Build TL721X drivers/adc
+      run: |
+        cd ..
+        west build -b tl7218x                  -d build_adc_tl721x                       zephyr/samples/drivers/adc                               -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
     # - name: Build TL721X net/openthread/cli
     #   run: |
     #     cd ..
@@ -100,10 +105,10 @@ jobs:
     #     cd ..
     #     west build -b tl7218x                  -d build_ot_echo_client_tl721x            zephyr/samples/net/sockets/echo_client                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DOVERLAY_CONFIG=overlay-ot-sed.conf -DCONFIG_OPENTHREAD_NETWORKKEY=\"09:24:01:56:04:4a:45:0b:23:22:1e:0e:3b:0d:0e:61:2f:1b:2c:24\"
 
-    # - name: Build TL721X subsys/usb/console for USB driver
-    #   run: |
-    #     cd ..
-    #     west build -b tl7218x                  -d build_usb_console_tl721x              zephyr/samples/subsys/usb/console                        -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+    - name: Build TL721X subsys/usb/console for USB driver
+      run: |
+        cd ..
+        west build -b tl7218x                  -d build_usb_console_tl721x              zephyr/samples/subsys/usb/console                        -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
     # - name: Build TL721X crypto/mbedtls
     #   run: |
@@ -121,6 +126,8 @@ jobs:
         cp ../build_sht3xd_tl721x/zephyr/zephyr.bin                    telink_build_artifacts/tl721x_sht3xd.bin
         cp ../build_hwinfo_tl721x/zephyr/zephyr.bin                    telink_build_artifacts/tl721x_hwinfo.bin
         cp ../build_peripheral_ht_tl721x/zephyr/zephyr.bin             telink_build_artifacts/tl721x_peripheral_ht.bin
+        cp ../build_adc_tl721x/zephyr/zephyr.bin                       telink_build_artifacts/tl721x_adc.bin
+        cp ../build_usb_console_tl721x/zephyr/zephyr.bin               telink_build_artifacts/tl721x_usb_console.bin
         cp ../modules/hal/telink/zephyr/blobs/lib_zephyr_tl721x.a      telink_build_artifacts/lib_zephyr_tl721x.a
 
     - name: Publish artifacts

--- a/drivers/adc/adc_tlx.c
+++ b/drivers/adc/adc_tlx.c
@@ -152,7 +152,7 @@ static signed short adc_tlx_get_code(void)
 {
 	signed short adc_code;
 
-#if  CONFIG_SOC_RISCV_TELINK_TL321X
+#if  CONFIG_SOC_RISCV_TELINK_TL321X || CONFIG_SOC_RISCV_TELINK_TL721X
 	static unsigned char g_adc_rx_fifo_index;
 
 	if (g_adc_rx_fifo_index == 0) {
@@ -162,14 +162,6 @@ static signed short adc_tlx_get_code(void)
 		adc_code = reg_adc_rxfifo_dat(g_adc_rx_fifo_index);
 		g_adc_rx_fifo_index = 0;
 	}
-#elif CONFIG_SOC_RISCV_TELINK_TL721X
-	analog_write_reg8(areg_adc_data_sample_control,
-		analog_read_reg8(areg_adc_data_sample_control) | FLD_NOT_SAMPLE_ADC_DATA);
-
-	adc_code = analog_read_reg16(areg_adc_misc_l);
-
-	analog_write_reg8(areg_adc_data_sample_control,
-		analog_read_reg8(areg_adc_data_sample_control) & (~FLD_NOT_SAMPLE_ADC_DATA));
 #endif
 	return adc_code;
 }
@@ -247,15 +239,10 @@ static void adc_tlx_acquisition_thread(const struct device *dev)
 	while (true) {
 		/* Wait for Acquisition semaphore */
 		k_sem_take(&data->acq_sem, K_FOREVER);
-#if  CONFIG_SOC_RISCV_TELINK_TL321X
+#if  CONFIG_SOC_RISCV_TELINK_TL321X || CONFIG_SOC_RISCV_TELINK_TL721X
 		adc_start_sample_nodma();
 		while (((reg_adc_rxfifo_trig_num & FLD_BUF_CNT) >> 4)
 				== 0){
-		}
-#elif CONFIG_SOC_RISCV_TELINK_TL721X
-		/* Wait for ADC data ready */
-		while ((analog_read_reg8(AREG_ADC_DATA_STATUS) & ADC_DATA_READY)
-				!= ADC_DATA_READY) {
 		}
 #endif
 		/* Perform read */

--- a/samples/drivers/adc/boards/tl7218x.overlay
+++ b/samples/drivers/adc/boards/tl7218x.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Telink Semiconductor (Shanghai) Co., Ltd.
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc 0>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <DT_ADC_VBAT>;
+	};
+};


### PR DESCRIPTION
1. fix the adc sample compilation errors
2. update the tl721x adc driver