### PR TITLE
riscv: b9x: save bin size for dlm.

### DIFF
--- a/soc/telink/tlsr/telink_b9x/matter_retention.ld
+++ b/soc/telink/tlsr/telink_b9x/matter_retention.ld
@@ -9,11 +9,20 @@
 /*
  * Moving BLE library sections (without suffix) to RAM DLM (non-retention)
  */
-SECTION_DATA_PROLOGUE(ram_dlm,,)
+SECTION_DATA_PROLOGUE(ram_dlm_data,,)
 {
 	. = ALIGN(4);
 	*(.data)
 	*(.sdata)
+
+	PROVIDE (_RAM_DLM_DATA_VMA_END = .);
+	PROVIDE (_RAM_DLM_DATA_VMA_START = ADDR(ram_dlm_data));
+	PROVIDE (_RAM_DLM_DATA_LMA_START = LOADADDR(ram_dlm_data));
+} GROUP_DATA_LINK_IN(TELINK_RAM_DATA_REGION, ROMABLE_REGION)
+
+SECTION_DATA_PROLOGUE(ram_dlm_bss,(NOLOAD),)
+{
+	. = ALIGN(4);
 	*(.bss)
 
 	/* Moving the BLE controller stack (HAL) */
@@ -28,10 +37,10 @@ SECTION_DATA_PROLOGUE(ram_dlm,,)
 	"*hci_core.c.obj*"(".noinit.*" ".bss.*")
 	"*l2cap.c.obj*"(".bss.*")
 
-	PROVIDE (_RAM_DLM_VMA_END = .);
-	PROVIDE (_RAM_DLM_VMA_START = ADDR(ram_dlm));
-	PROVIDE (_RAM_DLM_LMA_START = LOADADDR(ram_dlm));
-} GROUP_DATA_LINK_IN(TELINK_RAM_DATA_REGION, ROMABLE_REGION)
+	PROVIDE (_RAM_DLM_BSS_VMA_END = .);
+	PROVIDE (_RAM_DLM_BSS_VMA_START = ADDR(ram_dlm_bss));
+	PROVIDE (_RAM_DLM_BSS_LMA_START = LOADADDR(ram_dlm_bss));
+} GROUP_DATA_LINK_IN(TELINK_RAM_DATA_REGION, TELINK_RAM_DATA_REGION)
 
 /*
  * Moving BLE relative ramcode to special section

--- a/soc/telink/tlsr/telink_b9x/start.S
+++ b/soc/telink/tlsr/telink_b9x/start.S
@@ -98,16 +98,26 @@ _RAMCODE_BLE_INIT_BEGIN:
 	j      _RAMCODE_BLE_INIT_BEGIN
 
 _RAM_DLM_INIT:
-	la     t1, _RAM_DLM_LMA_START
-	la     t2, _RAM_DLM_VMA_START
-	la     t3, _RAM_DLM_VMA_END
+	la     t1, _RAM_DLM_DATA_LMA_START
+	la     t2, _RAM_DLM_DATA_VMA_START
+	la     t3, _RAM_DLM_DATA_VMA_END
 _RAM_DLM_BEGIN:
-	bleu   t3, t2, _RETENTION_RESET_INIT
+	bleu   t3, t2, _RAM_DLM_BSS_INIT
 	lw     t0, 0(t1)
 	sw     t0, 0(t2)
 	addi   t1, t1, 4
 	addi   t2, t2, 4
 	j      _RAM_DLM_BEGIN
+
+_RAM_DLM_BSS_INIT:
+	lui    t0, 0
+	la     t2, _RAM_DLM_BSS_VMA_START
+	la     t3, _RAM_DLM_BSS_VMA_END
+_ZERO_DLM_BSS_BEGIN:
+	bleu   t3, t2, _RETENTION_RESET_INIT
+	sw     t0, 0(t2)
+	addi   t2, t2, 4
+	j      _ZERO_DLM_BSS_BEGIN
 #endif /* CONFIG_TELINK_B9X_MATTER_RETENTION_LAYOUT */
 
 _RETENTION_RESET_INIT:


### PR DESCRIPTION
- seperate dlm_bss and dlm_data to save bin.
- load dlm_data and reset dlm_bss .