### PR TITLE
telink: tl721x: add spi driver for Tercel A1

### DIFF
--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -85,6 +85,11 @@ jobs:
         cd ..
         west build -b tl7218x                  -d build_adc_tl721x                       zephyr/samples/drivers/adc                               -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
+    - name: Build TL721x samples/drivers/spi_flash
+      run: |
+        cd ..
+        west build -b tl7218x                  -d build_spi_flash_tl721x                 zephyr/samples/drivers/spi_flash                        -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
     # - name: Build TL721X net/openthread/cli
     #   run: |
     #     cd ..
@@ -129,6 +134,7 @@ jobs:
         cp ../build_adc_tl721x/zephyr/zephyr.bin                       telink_build_artifacts/tl721x_adc.bin
         cp ../build_usb_console_tl721x/zephyr/zephyr.bin               telink_build_artifacts/tl721x_usb_console.bin
         cp ../build_crypto_mbedtls_tl721x/zephyr/zephyr.bin            telink_build_artifacts/tl721x_mbedtls.bin
+        cp ../build_spi_flash_tl721x/zephyr/zephyr.bin                 telink_build_artifacts/tl721x_spi_flash.bin
         cp ../modules/hal/telink/zephyr/blobs/lib_zephyr_tl721x.a      telink_build_artifacts/lib_zephyr_tl721x.a
 
     - name: Publish artifacts

--- a/boards/riscv/tl721x/tl7218x-common.dtsi
+++ b/boards/riscv/tl721x/tl7218x-common.dtsi
@@ -208,8 +208,8 @@
 
 &gspi {
 	status = "okay";
-	cs0-pin = "GPIO_PA1";
-	pinctrl-0 = <&gspi_clk_pa2_default &gspi_miso_pa3_default &gspi_mosi_pa4_default>;
+	cs0-pin = "GPIO_PF3";
+	pinctrl-0 = <&gspi_clk_pf4_default &gspi_miso_pf6_default &gspi_mosi_pf7_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/riscv/tl721x/tl7218x-pinctrl.dtsi
+++ b/boards/riscv/tl721x/tl7218x-pinctrl.dtsi
@@ -62,16 +62,16 @@
 		pinmux = <TLX_PINMUX_SET(TLX_PORT_E, TLX_PIN_3, TL721X_FUNC_DEFAULT)>;
 	};
 
-	/* GSPI: CLK(PA2), MOSI(PA4), MISO(PA3) */
+	/* GSPI: CLK(PF4), MOSI(PF7), MISO(PF6) */
 
-	gspi_clk_pa2_default: gspi_clk_pa2_default {
-		pinmux = <TLX_PINMUX_SET(TLX_PORT_A, TLX_PIN_2, TL721X_FUNC_GSPI_CK_IO)>;
+	gspi_clk_pf4_default: gspi_clk_pf4_default {
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_F, TLX_PIN_4, TL721X_FUNC_GSPI_CK_IO)>;
 	};
-	gspi_mosi_pa4_default: gspi_mosi_pa4_default {
-		pinmux = <TLX_PINMUX_SET(TLX_PORT_A, TLX_PIN_4, TL721X_FUNC_GSPI_MOSI_IO)>;
+	gspi_mosi_pf7_default: gspi_mosi_pf7_default {
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_F, TLX_PIN_7, TL721X_FUNC_GSPI_MOSI_IO)>;
 	};
-	gspi_miso_pa3_default: gspi_miso_pa3_default {
-		pinmux = <TLX_PINMUX_SET(TLX_PORT_A, TLX_PIN_3, TL721X_FUNC_GSPI_MISO_IO)>;
+	gspi_miso_pf6_default: gspi_miso_pf6_default {
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_F, TLX_PIN_6, TL721X_FUNC_GSPI_MISO_IO)>;
 	};
 
 	/* Define I2C pins: SCL(PE6), SDA(PE7) */

--- a/drivers/spi/Kconfig.tlx
+++ b/drivers/spi/Kconfig.tlx
@@ -4,6 +4,6 @@
 config SPI_TELINK_TLX
 	bool "Telink Semiconductor TLx SPI driver"
 	default y
-	depends on DT_HAS_TELINK_TL321X_SPI_ENABLED
+	depends on DT_HAS_TELINK_TL321X_SPI_ENABLED || DT_HAS_TELINK_TL721X_SPI_ENABLED
 	help
 	  Enables Telink TLx SPI driver.

--- a/drivers/spi/spi_tlx.c
+++ b/drivers/spi/spi_tlx.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#if CONFIG_SOC_RISCV_TELINK_TL321X
 #define DT_DRV_COMPAT telink_tl321x_spi
+#elif CONFIG_SOC_RISCV_TELINK_TL721X
+#define DT_DRV_COMPAT telink_tl721x_spi
+#endif
 
 /*  Redefine 'spi_read' and 'spi_write' functions names from HAL */
 #define spi_read    hal_spi_read
@@ -123,7 +127,7 @@ static bool spi_tlx_config_cs(const struct device *dev,
 				/* Note: lspi_cs_pin_en has not added to SPI driver for B92,
 				 * lspi_cs_pin_en must call lspi_set_pin_mux
 				 */
-				lspi_set_pin_mux(cs_pin);
+				lspi_set_pin_mux(cs_pin, LSPI_CN_IO);
 			} else {
 				gspi_cs_pin_en(cs_pin);
 			}

--- a/dts/bindings/spi/telink,tl721x-spi.yaml
+++ b/dts/bindings/spi/telink,tl721x-spi.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) 2024, Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+description: Telink TL721X SPI
+
+include: spi-controller.yaml
+
+compatible: "telink,tl721x-spi"
+
+properties:
+  reg:
+    required: true
+
+  peripheral-id:
+    type: string
+    required: true
+    enum:
+      - "LSPI_MODULE"
+      - "GSPI_MODULE"
+
+  pinctrl-0:
+    type: phandles
+    required: true
+
+  cs0-pin:
+    type: string
+    required: true
+    enum:
+      - "0"
+      - "LSPI_CSN_PE0_PIN"
+      - "GPIO_PF3"
+      - "GPIO_PB6"
+
+  cs1-pin:
+    type: string
+    enum:
+      - "0"
+      - "LSPI_CSN_PE0_PIN"
+      - "GPIO_PF3"
+      - "GPIO_PB6"
+
+  cs2-pin:
+    type: string
+    enum:
+      - "0"
+      - "LSPI_CSN_PE0_PIN"
+      - "GPIO_PF3"
+      - "GPIO_PB6"

--- a/samples/drivers/spi_flash/boards/tl7218x.overlay
+++ b/samples/drivers/spi_flash/boards/tl7218x.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Telink Semiconductor (Shanghai) Co., Ltd.
+ */
+
+/ {
+	aliases {
+		spi-flash0 = &spi1_cs0_flash;
+	};
+};
+
+
+&gspi {
+	status = "okay";
+		spi1_cs0_flash: p25q16@0 {
+		compatible = "jedec,spi-nor";
+		/* 16777216 bits = 2 Mbytes */
+		size = <0x1000000>;
+		reg = <0>;
+		spi-max-frequency = <800000>;
+		jedec-id = [ef 40 16];
+		status = "okay";
+	};
+};


### PR DESCRIPTION
- add spi driver for Tercel A1
- modify the pins for GSPI
- set the spi-max-frequency of tl721x to 800000