### PR TITLE
telink: Update telink-tl321x-build.yaml

### DIFF
--- a/.github/workflows/telink-tl321x-build.yaml
+++ b/.github/workflows/telink-tl321x-build.yaml
@@ -100,7 +100,12 @@ jobs:
     - name: Build TL321x net/openthread/coprocessor in RCP configuration with UART interface
       run: |
         cd ..
-        west build -b tl3218      -d build_ot_coprocessor_rcp_uart_tl3218     zephyr/samples/net/openthread/coprocessor     -- -DOVERLAY_CONFIG=overlay-rcp.conf
+        west build -b tl3218      -d build_ot_coprocessor_rcp_uart_tl3218     zephyr/samples/net/openthread/coprocessor     -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DOVERLAY_CONFIG=overlay-rcp.conf
+
+    - name: Build TL321X net/openthread/coprocessor in RCP configuration with USB interface
+      run: |
+        cd ..
+        west build -b tl3218     -d build_ot_coprocessor_rcp_usb_tl3218      zephyr/samples/net/openthread/coprocessor     -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DDTC_OVERLAY_FILE="usb.overlay boards/tl3218-dongle.overlay" -DOVERLAY_CONFIG=overlay-rcp-usb-telink.conf
 
     - name: Build TL321x subsys/usb/console for USB driver
       run: |
@@ -132,6 +137,7 @@ jobs:
         cp ../build_peripheral_ht_tl3218/zephyr/zephyr.bin              telink_build_artifacts/tl3218_peripheral_ht.bin
         cp ../build_ot_cli_tl3218/zephyr/zephyr.bin                     telink_build_artifacts/tl3218_ot_cli.bin
         cp ../build_ot_coprocessor_rcp_uart_tl3218/zephyr/zephyr.bin    telink_build_artifacts/tl3218_ot_coprocessor_rcp_uart.bin
+        cp ../build_ot_coprocessor_rcp_usb_tl3218/zephyr/zephyr.bin    telink_build_artifacts/tl3218_ot_coprocessor_rcp_usb.bin
         cp ../build_usb_console_tl3218/zephyr/zephyr.bin                telink_build_artifacts/tl3218_usb_console.bin
         cp ../build_crypto_mbedtls_tl3218/zephyr/zephyr.bin             telink_build_artifacts/tl3218_mbedtls.bin
 

--- a/samples/net/openthread/coprocessor/boards/tl3218-dongle.overlay
+++ b/samples/net/openthread/coprocessor/boards/tl3218-dongle.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/tl321x-pinctrl.h>
+
+/ {
+	chosen {
+		zephyr,console = &uart0;
+	};
+};


### PR DESCRIPTION
- enable COMPILER_WARNINGS_AS_ERRORS for rcp demo.
- add rcp usb demo.
- add tl3218-dongle.overlay.