### PR TITLE
telink: crypto: mbedtls: Add missed wrappers for MbedTLS HW acceleration

### DIFF
--- a/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
@@ -84,6 +84,9 @@ zephyr_link_libraries(
 	-Wl,--wrap,mbedtls_ecp_mul_restartable
 	-Wl,--wrap,mbedtls_ecp_muladd
 	-Wl,--wrap,mbedtls_ecp_muladd_restartable
+	-Wl,--wrap,mbedtls_ecp_gen_key
+	-Wl,--wrap,mbedtls_ecp_gen_keypair
+	-Wl,--wrap,mbedtls_ecp_gen_keypair_base
 	-Wl,--wrap,mbedtls_ecp_self_test
 )
 endif()

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: ec586d963cde41293340fd4b0697cf726afaf6a4
+      revision: 54c4302c9038d2cf412348400bcd039f5674da91
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Add missed wrappers for MbedTLS HW acceleration
Part of PR: https://github.com/telink-semi/zephyr/pull/351

```
-Wl,--wrap,mbedtls_ecp_gen_key
-Wl,--wrap,mbedtls_ecp_gen_keypair
-Wl,--wrap,mbedtls_ecp_gen_keypair_base
```


