### PR TITLE
telink: Fix flash configuration

### DIFF
--- a/boards/telink/tl3218/Kconfig.defconfig
+++ b/boards/telink/tl3218/Kconfig.defconfig
@@ -24,6 +24,10 @@ config FLASH_LOAD_OFFSET
 
 if MCUBOOT
 
+config IMG_ERASE_PROGRESSIVELY
+	bool
+	default y
+
 config MCUBOOT_ACTION_HOOKS
 	bool
 	default y

--- a/boards/telink/tlsr9118bdk40d/Kconfig.defconfig
+++ b/boards/telink/tlsr9118bdk40d/Kconfig.defconfig
@@ -24,6 +24,10 @@ config FLASH_LOAD_OFFSET
 
 if MCUBOOT
 
+config IMG_ERASE_PROGRESSIVELY
+	bool
+	default y
+
 config MCUBOOT_ACTION_HOOKS
 	bool
 	default y

--- a/boards/telink/tlsr9258a/Kconfig.defconfig
+++ b/boards/telink/tlsr9258a/Kconfig.defconfig
@@ -24,6 +24,10 @@ config FLASH_LOAD_OFFSET
 
 if MCUBOOT
 
+config IMG_ERASE_PROGRESSIVELY
+	bool
+	default y
+
 config MCUBOOT_ACTION_HOOKS
 	bool
 	default y

--- a/boards/telink/tlsr9518adk80d/Kconfig.defconfig
+++ b/boards/telink/tlsr9518adk80d/Kconfig.defconfig
@@ -24,6 +24,10 @@ config FLASH_LOAD_OFFSET
 
 if MCUBOOT
 
+config IMG_ERASE_PROGRESSIVELY
+	bool
+	default y
+
 config MCUBOOT_ACTION_HOOKS
 	bool
 	default y

--- a/boards/telink/tlsr9528a/Kconfig.defconfig
+++ b/boards/telink/tlsr9528a/Kconfig.defconfig
@@ -24,6 +24,10 @@ config FLASH_LOAD_OFFSET
 
 if MCUBOOT
 
+config IMG_ERASE_PROGRESSIVELY
+	bool
+	default y
+
 config MCUBOOT_ACTION_HOOKS
 	bool
 	default y

--- a/soc/telink/tlsr/telink_b9x/Kconfig.defconfig
+++ b/soc/telink/tlsr/telink_b9x/Kconfig.defconfig
@@ -34,7 +34,7 @@ config XIP
 config FLASH
 	default y
 
-config FLASH_HAS_NO_EXPLICIT_ERASE
+config FLASH_HAS_EXPLICIT_ERASE
 	default y
 
 config STACK_SENTINEL

--- a/soc/telink/tlsr/telink_tlx/Kconfig.defconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig.defconfig
@@ -33,7 +33,7 @@ config XIP
 config FLASH
 	default y
 
-config FLASH_HAS_NO_EXPLICIT_ERASE
+config FLASH_HAS_EXPLICIT_ERASE
 	default y
 
 config STACK_SENTINEL

--- a/soc/telink/tlsr/telink_w9x/Kconfig.defconfig
+++ b/soc/telink/tlsr/telink_w9x/Kconfig.defconfig
@@ -43,7 +43,7 @@ config FLASH
 	bool
 	default y
 
-config FLASH_HAS_NO_EXPLICIT_ERASE
+config FLASH_HAS_EXPLICIT_ERASE
 	bool
 	default y
 


### PR DESCRIPTION
MCU boot require setting config IMG_ERASE_PROGRESSIVELY to erasing flash download area during its updating otherwise all area is erased at the beginning of image downloading. It's leading to communication timeouts due to long erasing time.