### PR TITLE
telink: B92&TL321X: add exit latency mechanism.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 14f11fc384682dbda2ad50c8c3befa99fb181b1a
+      revision: pull/130/head
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- add suspend & deepretn exit latency mechanism to avoid BLE disconn issue.
-  add `blc_ll_checkBleRfFsmIsIdle` api to check if rf fsm is idle.

Signed-off-by: Zhihan Tao <zhihan.tao@telink-semi.com>