### PR TITLE
telink: Fix chip id printing condition

### DIFF
--- a/.github/workflows/telink-b92-build.yaml
+++ b/.github/workflows/telink-b92-build.yaml
@@ -91,7 +91,12 @@ jobs:
     - name: Build B92 bootloader/mcuboot/boot
       run: |
         cd ..
-        west build -b tlsr9528a                  -d build_mcuboot_b92                   bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3 -DCONFIG_BOOT_MAX_IMG_SECTORS=4096
+        west build -b tlsr9528a                  -d build_mcuboot_b92                   bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3
+
+    - name: Build B92 bootloader/mcuboot/boot - chip id
+      run: |
+        cd ..
+        west build -b tlsr9528a                  -d build_mcuboot_chip_id_b92           bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3 -DCONFIG_TELINK_B9X_MCUBOOT_STARTUP=y
 
     - name: Build B92 subsys/mgmt/mcumgr/smp_svr for Bluetooth
       run: |
@@ -156,6 +161,7 @@ jobs:
         cp ../build_ot_echo_client_b92/zephyr/zephyr.bin            telink_build_artifacts/b92_ot_echo_client.bin
         cp ../build_ot_echo_client_pm_b92/zephyr/zephyr.bin         telink_build_artifacts/b92_ot_echo_client_pm.bin
         cp ../build_mcuboot_b92/zephyr/zephyr.bin                   telink_build_artifacts/b92_mcuboot.bin
+        cp ../build_mcuboot_chip_id_b92/zephyr/zephyr.bin           telink_build_artifacts/b92_mcuboot_chip_id.bin
         cp ../build_bt_smp_svr_b92/zephyr/zephyr.signed.bin         telink_build_artifacts/b92_bt_smp_svr.signed.bin
         cp ../build_usb_console_b92/zephyr/zephyr.bin               telink_build_artifacts/b92_usb_console.bin
         cp ../build_ot_coprocessor_rcp_usb_b92/zephyr/zephyr.bin    telink_build_artifacts/b92_ot_coprocessor_rcp_usb.bin

--- a/.github/workflows/telink-tl321x-build.yaml
+++ b/.github/workflows/telink-tl321x-build.yaml
@@ -122,6 +122,11 @@ jobs:
         cd ..
         west build -b tl3218      -d build_mcuboot_tl3218_lzma                bootloader/mcuboot/boot/zephyr                -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_COMPRESS_LZMA=y -DCONFIG_BOOT_UPGRADE_ONLY=y
 
+    - name: Build TL321X bootloader/mcuboot/boot - chip id
+      run: |
+        cd ..
+        west build -b tl3218      -d build_mcuboot_chip_id_tl3218             bootloader/mcuboot/boot/zephyr                -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3 -DCONFIG_TELINK_TLX_MCUBOOT_STARTUP=y
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
@@ -137,9 +142,10 @@ jobs:
         cp ../build_peripheral_ht_tl3218/zephyr/zephyr.bin              telink_build_artifacts/tl3218_peripheral_ht.bin
         cp ../build_ot_cli_tl3218/zephyr/zephyr.bin                     telink_build_artifacts/tl3218_ot_cli.bin
         cp ../build_ot_coprocessor_rcp_uart_tl3218/zephyr/zephyr.bin    telink_build_artifacts/tl3218_ot_coprocessor_rcp_uart.bin
-        cp ../build_ot_coprocessor_rcp_usb_tl3218/zephyr/zephyr.bin    telink_build_artifacts/tl3218_ot_coprocessor_rcp_usb.bin
+        cp ../build_ot_coprocessor_rcp_usb_tl3218/zephyr/zephyr.bin     telink_build_artifacts/tl3218_ot_coprocessor_rcp_usb.bin
         cp ../build_usb_console_tl3218/zephyr/zephyr.bin                telink_build_artifacts/tl3218_usb_console.bin
         cp ../build_crypto_mbedtls_tl3218/zephyr/zephyr.bin             telink_build_artifacts/tl3218_mbedtls.bin
+        cp ../build_mcuboot_chip_id_tl3218/zephyr/zephyr.bin            telink_build_artifacts/tl3218_mcuboot_chip_id.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v3

--- a/boards/telink/tl3218/tl3218-pinctrl.dtsi
+++ b/boards/telink/tl3218/tl3218-pinctrl.dtsi
@@ -18,13 +18,15 @@
 		pinmux = <TLX_PINMUX_SET(TLX_PORT_E, TLX_PIN_0, TL321X_FUNC_UART0_TX)>;
 	};
 	uart0_rx_pe1_default: uart0_rx_pe1_default {
-		pinmux = <TLX_PINMUX_SET(TLX_PORT_E, TLX_PIN_1, TL321X_FUNC_UART0_RTX_IO)>;
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_E, TLX_PIN_1,
+				(TL321X_FUNC_UART0_RTX_IO | TL321X_PULL_UP))>;
 	};
 	uart0_rts_pe2_default: uart0_rts_pe2_default {
 		pinmux = <TLX_PINMUX_SET(TLX_PORT_E, TLX_PIN_2, TL321X_FUNC_UART0_RTS)>;
 	};
 	uart0_cts_pe3_default: uart0_cts_pe3_default {
-		pinmux = <TLX_PINMUX_SET(TLX_PORT_E, TLX_PIN_3, TL321X_FUNC_UART0_CTS_I)>;
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_E, TLX_PIN_3,
+				(TL321X_FUNC_UART0_CTS_I | TL321X_PULL_UP))>;
 	};
 
 	/* UART1: TX(PC6), RX(PC7), RTS(PC5), CTS(PC4) */
@@ -33,13 +35,15 @@
 		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_6, TL321X_FUNC_UART1_TX)>;
 	};
 	uart1_rx_pc7_default: uart1_rx_pc7_default {
-		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_7, TL321X_FUNC_UART1_RTX_IO)>;
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_7,
+				(TL321X_FUNC_UART1_RTX_IO | TL321X_PULL_UP))>;
 	};
 	uart1_rts_pc5_default: uart1_rts_pc5_default {
 		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_5, TL321X_FUNC_UART1_RTS)>;
 	};
 	uart1_cts_pc4_default: uart1_cts_pc4_default {
-		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_4, TL321X_FUNC_UART1_CTS_I)>;
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_4,
+				(TL321X_FUNC_UART1_CTS_I | TL321X_PULL_UP))>;
 	};
 
 	/* PWM Channel 0 (PE4) */

--- a/boards/telink/tlsr9258a/tlsr9258a-pinctrl.dtsi
+++ b/boards/telink/tlsr9258a/tlsr9258a-pinctrl.dtsi
@@ -15,7 +15,7 @@
 	/* UART0: TX(PB2), RX(PB3), RTS(PB4), CTS(PB6) */
 
 	uart0_tx_pb2_default: uart0_tx_pb2_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, (B95_FUNC_UART0_TX | B95_PULL_UP))>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, B95_FUNC_UART0_TX)>;
 	};
 	uart0_rx_pb3_default: uart0_rx_pb3_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3,
@@ -25,7 +25,8 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_4, B95_FUNC_UART0_RTS)>;
 	};
 	uart0_cts_pb6_default: uart0_cts_pb6_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, B95_FUNC_UART0_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6,
+				(B95_FUNC_UART0_CTS_I | B95_PULL_UP))>;
 	};
 
 	/* UART1: TX(PC6), RX(PC7), RTS(PC5), CTS(PC4) */
@@ -34,13 +35,15 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_6, B95_FUNC_UART1_TX)>;
 	};
 	uart1_rx_pc7_default: uart1_rx_pc7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, B95_FUNC_UART1_RTX_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7,
+				(B95_FUNC_UART1_RTX_IO | B95_PULL_UP))>;
 	};
 	uart1_rts_pc5_default: uart1_rts_pc5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_5, B95_FUNC_UART1_RTS)>;
 	};
 	uart1_cts_pc4_default: uart1_cts_pc4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, B95_FUNC_UART1_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4,
+				(B95_FUNC_UART1_CTS_I | B95_PULL_UP))>;
 	};
 
 	/* PWM Channel 0 (PB7) */

--- a/boards/telink/tlsr9518adk80d/tlsr9518adk80d-pinctrl.dtsi
+++ b/boards/telink/tlsr9518adk80d/tlsr9518adk80d-pinctrl.dtsi
@@ -18,13 +18,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, B91_FUNC_C)>;
 	};
 	uart0_rx_pb3_default: uart0_rx_pb3_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 	uart0_rts_pb4_default: uart0_rts_pb4_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_4, B91_FUNC_C)>;
 	};
 	uart0_cts_pb6_default: uart0_cts_pb6_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 
 	/* UART0: TX(PA3), RX(PA4), RTS(PA2), CTS(PA1) */
@@ -33,13 +33,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_3, B91_FUNC_B)>;
 	};
 	uart0_rx_pa4_default: uart0_rx_pa4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_4, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_4, (B91_FUNC_B | B91_PULL_UP))>;
 	};
 	uart0_rts_pa2_default: uart0_rts_pa2_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_2, B91_FUNC_B)>;
 	};
 	uart0_cts_pa1_default: uart0_cts_pa1_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_1, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_1, (B91_FUNC_B | B91_PULL_UP))>;
 	};
 
 	/* UART0: TX(PD2), RX(PD3), RTS(PD1), CTS(PD0) */
@@ -48,13 +48,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_2, B91_FUNC_A)>;
 	};
 	uart0_rx_pd3_default: uart0_rx_pd3_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_3, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_3, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 	uart0_rts_pd1_default: uart0_rts_pd1_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_1, B91_FUNC_A)>;
 	};
 	uart0_cts_pd0_default: uart0_cts_pd0_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_0, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_0, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 
 	/* UART1: TX(PC6), RX(PC7), RTS(PC5), CTS(PC4) */
@@ -63,13 +63,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_6, B91_FUNC_C)>;
 	};
 	uart1_rx_pc7_default: uart1_rx_pc7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 	uart1_rts_pc5_default: uart1_rts_pc5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_5, B91_FUNC_C)>;
 	};
 	uart1_cts_pc4_default: uart1_cts_pc4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 
 	/* UART1: TX(PD6), RX(PD7), RTS(PD5), CTS(PD4) */
@@ -78,13 +78,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_6, B91_FUNC_A)>;
 	};
 	uart1_rx_pd7_default: uart1_rx_pd7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_7, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_7, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 	uart1_rts_pd5_default: uart1_rts_pd5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_5, B91_FUNC_A)>;
 	};
 	uart1_cts_pd4_default: uart1_cts_pd4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_4, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_4, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 
 	/* UART1: TX(PE0), RX(PE2), RTS(PE3), CTS(PE1) */
@@ -93,13 +93,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_0, B91_FUNC_B)>;
 	};
 	uart1_rx_pe2_default: uart1_rx_pe2_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_2, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_2, (B91_FUNC_B | B91_PULL_UP))>;
 	};
 	uart1_rts_pe3_default: uart1_rts_pe3_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_3, B91_FUNC_B)>;
 	};
 	uart1_cts_pe1_default: uart1_cts_pe1_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_1, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_1, (B91_FUNC_B | B91_PULL_UP))>;
 	};
 
 	/* PWM Channel 0 (PB4) */

--- a/boards/telink/tlsr9528a/tlsr9528a-pinctrl.dtsi
+++ b/boards/telink/tlsr9528a/tlsr9528a-pinctrl.dtsi
@@ -18,13 +18,15 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, B92_FUNC_UART0_TX)>;
 	};
 	uart0_rx_pb3_default: uart0_rx_pb3_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3, B92_FUNC_UART0_RTX_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3,
+				(B92_FUNC_UART0_RTX_IO | B92_PULL_UP))>;
 	};
 	uart0_rts_pb4_default: uart0_rts_pb4_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_4, B92_FUNC_UART0_RTS)>;
 	};
 	uart0_cts_pb6_default: uart0_cts_pb6_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, B92_FUNC_UART0_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6,
+				(B92_FUNC_UART0_CTS_I | B92_PULL_UP))>;
 	};
 
 	/* UART1: TX(PC6), RX(PC7), RTS(PC5), CTS(PC4) */
@@ -33,13 +35,15 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_6, B92_FUNC_UART1_TX)>;
 	};
 	uart1_rx_pc7_default: uart1_rx_pc7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, B92_FUNC_UART1_RTX_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7,
+				(B92_FUNC_UART1_RTX_IO | B92_PULL_UP))>;
 	};
 	uart1_rts_pc5_default: uart1_rts_pc5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_5, B92_FUNC_UART1_RTS)>;
 	};
 	uart1_cts_pc4_default: uart1_cts_pc4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, B92_FUNC_UART1_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4,
+				(B92_FUNC_UART1_CTS_I | B92_PULL_UP))>;
 	};
 
 	/* PWM Channel 0 (PD0) */

--- a/include/zephyr/dt-bindings/pinctrl/b91-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/b91-pinctrl.h
@@ -62,6 +62,10 @@
 #define B9x_PIN_MSK      0xFFFF
 #define B9x_PIN_ID_MSK   0xFF
 
+#define B91_PULL_NONE    (B9x_PULL_NONE << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B91_PULL_DOWN    (B9x_PULL_DOWN << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B91_PULL_UP      (B9x_PULL_UP << (B9x_PULL_POS - B9x_FUNC_POS))
+
 /* Setters and getters */
 
 #define B9x_PINMUX_SET(port, pin, func)   ((func << B9x_FUNC_POS) | \

--- a/include/zephyr/dt-bindings/pinctrl/b92-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/b92-pinctrl.h
@@ -128,6 +128,10 @@
 #define B9x_PIN_MSK      0xFFFF
 #define B9x_PIN_ID_MSK   0xFF
 
+#define B92_PULL_NONE    (B9x_PULL_NONE << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B92_PULL_DOWN    (B9x_PULL_DOWN << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B92_PULL_UP      (B9x_PULL_UP << (B9x_PULL_POS - B9x_FUNC_POS))
+
 /* Setters and getters */
 
 #define B9x_PINMUX_SET(port, pin, func)   ((func << B9x_FUNC_POS) | \

--- a/include/zephyr/dt-bindings/pinctrl/tl321x-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/tl321x-pinctrl.h
@@ -142,6 +142,10 @@
 #define TLX_PIN_POS      0
 #define TLX_PIN_MSK      0xFFFF
 #define TLX_PIN_ID_MSK   0xFF
+/* pull configuration */
+#define TL321X_PULL_NONE    (TLX_PULL_NONE << (TLX_PULL_POS - TLX_FUNC_POS))
+#define TL321X_PULL_DOWN    (TLX_PULL_DOWN << (TLX_PULL_POS - TLX_FUNC_POS))
+#define TL321X_PULL_UP      (TLX_PULL_UP << (TLX_PULL_POS - TLX_FUNC_POS))
 /* Setters and getters */
 #define TLX_PINMUX_SET(port, pin, func)   ((func << TLX_FUNC_POS) | \
 					    (port << TLX_PORT_POS) | \

--- a/soc/telink/tlsr/telink_b9x/Kconfig
+++ b/soc/telink/tlsr/telink_b9x/Kconfig
@@ -105,6 +105,8 @@ if BOOTLOADER_MCUBOOT || MCUBOOT
 config TELINK_B9X_MCUBOOT_STARTUP
 	bool "Telink B9x MCUBoot startup handler"
 	depends on MCUBOOT
+	select CRC
+	select UART_DRV_CMD
 	help
 		Run Telink specific vendor code before MCUBoot
 		main process

--- a/soc/telink/tlsr/telink_tlx/Kconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig
@@ -103,6 +103,8 @@ if BOOTLOADER_MCUBOOT || MCUBOOT
 config TELINK_TLX_MCUBOOT_STARTUP
 	bool "Telink TLx MCUBoot startup handler"
 	depends on MCUBOOT
+	select CRC
+	select UART_DRV_CMD
 	help
 		Run Telink specific vendor code before MCUBoot
 		main process


### PR DESCRIPTION
- fix build
- apply pull-up to UART input pins
- since there is no UART API which reliable detects UART break condition GPIO is used instead of it (low line level). Added vendor API which counts logical low UART lines level.