### PR TITLE
telink: Fix chip id printing condition

### DIFF
--- a/.github/workflows/telink-b92-build.yaml
+++ b/.github/workflows/telink-b92-build.yaml
@@ -90,6 +90,11 @@ jobs:
         cd ..
         west build -b tlsr9528a                  -d build_mcuboot_b92                   bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3 -DCONFIG_BOOT_MAX_IMG_SECTORS=4096
 
+    - name: Build B92 bootloader/mcuboot/boot - chip id
+      run: |
+        cd ..
+        west build -b tlsr9528a                  -d build_mcuboot_chip_id_b92           bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3 -DCONFIG_BOOT_MAX_IMG_SECTORS=4096 -DCONFIG_TELINK_B9X_MCUBOOT_STARTUP=y
+
     - name: Build B92 bootloader/mcuboot/boot for compressed LZMA image
       run: |
         cd ..
@@ -159,6 +164,7 @@ jobs:
         cp ../build_ot_echo_client_b92/zephyr/zephyr.bin            telink_build_artifacts/b92_ot_echo_client.bin
         cp ../build_ot_echo_client_pm_b92/zephyr/zephyr.bin         telink_build_artifacts/b92_ot_echo_client_pm.bin
         cp ../build_mcuboot_b92/zephyr/zephyr.bin                   telink_build_artifacts/b92_mcuboot.bin
+        cp ../build_mcuboot_chip_id_b92/zephyr/zephyr.bin           telink_build_artifacts/b92_mcuboot_chip_id.bin
         cp ../build_bt_smp_svr_b92/zephyr/zephyr.signed.bin         telink_build_artifacts/b92_bt_smp_svr.signed.bin
         cp ../build_usb_console_b92/zephyr/zephyr.bin               telink_build_artifacts/b92_usb_console.bin
         cp ../build_ot_coprocessor_rcp_usb_b92/zephyr/zephyr.bin    telink_build_artifacts/b92_ot_coprocessor_rcp_usb.bin

--- a/boards/riscv/tlsr9258a/tlsr9258a-pinctrl.dtsi
+++ b/boards/riscv/tlsr9258a/tlsr9258a-pinctrl.dtsi
@@ -15,7 +15,7 @@
 	/* UART0: TX(PB2), RX(PB3), RTS(PB4), CTS(PB6) */
 
 	uart0_tx_pb2_default: uart0_tx_pb2_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, (B95_FUNC_UART0_TX | B95_PULL_UP))>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, B95_FUNC_UART0_TX)>;
 	};
 	uart0_rx_pb3_default: uart0_rx_pb3_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3,
@@ -25,7 +25,8 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_4, B95_FUNC_UART0_RTS)>;
 	};
 	uart0_cts_pb6_default: uart0_cts_pb6_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, B95_FUNC_UART0_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6,
+				(B95_FUNC_UART0_CTS_I | B95_PULL_UP))>;
 	};
 
 	/* UART1: TX(PC6), RX(PC7), RTS(PC5), CTS(PC4) */
@@ -34,13 +35,15 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_6, B95_FUNC_UART1_TX)>;
 	};
 	uart1_rx_pc7_default: uart1_rx_pc7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, B95_FUNC_UART1_RTX_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7,
+				(B95_FUNC_UART1_RTX_IO | B95_PULL_UP))>;
 	};
 	uart1_rts_pc5_default: uart1_rts_pc5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_5, B95_FUNC_UART1_RTS)>;
 	};
 	uart1_cts_pc4_default: uart1_cts_pc4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, B95_FUNC_UART1_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4,
+				(B95_FUNC_UART1_CTS_I  | B95_PULL_UP))>;
 	};
 
 	/* PWM Channel 0 (PB7) */

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-pinctrl.dtsi
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-pinctrl.dtsi
@@ -18,13 +18,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, B91_FUNC_C)>;
 	};
 	uart0_rx_pb3_default: uart0_rx_pb3_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 	uart0_rts_pb4_default: uart0_rts_pb4_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_4, B91_FUNC_C)>;
 	};
 	uart0_cts_pb6_default: uart0_cts_pb6_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 
 	/* UART0: TX(PA3), RX(PA4), RTS(PA2), CTS(PA1) */
@@ -33,13 +33,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_3, B91_FUNC_B)>;
 	};
 	uart0_rx_pa4_default: uart0_rx_pa4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_4, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_4, (B91_FUNC_B  | B91_PULL_UP))>;
 	};
 	uart0_rts_pa2_default: uart0_rts_pa2_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_2, B91_FUNC_B)>;
 	};
 	uart0_cts_pa1_default: uart0_cts_pa1_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_1, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_A, B9x_PIN_1, (B91_FUNC_B | B91_PULL_UP))>;
 	};
 
 	/* UART0: TX(PD2), RX(PD3), RTS(PD1), CTS(PD0) */
@@ -48,13 +48,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_2, B91_FUNC_A)>;
 	};
 	uart0_rx_pd3_default: uart0_rx_pd3_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_3, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_3, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 	uart0_rts_pd1_default: uart0_rts_pd1_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_1, B91_FUNC_A)>;
 	};
 	uart0_cts_pd0_default: uart0_cts_pd0_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_0, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_0, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 
 	/* UART1: TX(PC6), RX(PC7), RTS(PC5), CTS(PC4) */
@@ -63,13 +63,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_6, B91_FUNC_C)>;
 	};
 	uart1_rx_pc7_default: uart1_rx_pc7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 	uart1_rts_pc5_default: uart1_rts_pc5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_5, B91_FUNC_C)>;
 	};
 	uart1_cts_pc4_default: uart1_cts_pc4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, B91_FUNC_C)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, (B91_FUNC_C | B91_PULL_UP))>;
 	};
 
 	/* UART1: TX(PD6), RX(PD7), RTS(PD5), CTS(PD4) */
@@ -78,13 +78,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_6, B91_FUNC_A)>;
 	};
 	uart1_rx_pd7_default: uart1_rx_pd7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_7, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_7, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 	uart1_rts_pd5_default: uart1_rts_pd5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_5, B91_FUNC_A)>;
 	};
 	uart1_cts_pd4_default: uart1_cts_pd4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_4, B91_FUNC_A)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_D, B9x_PIN_4, (B91_FUNC_A | B91_PULL_UP))>;
 	};
 
 	/* UART1: TX(PE0), RX(PE2), RTS(PE3), CTS(PE1) */
@@ -93,13 +93,13 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_0, B91_FUNC_B)>;
 	};
 	uart1_rx_pe2_default: uart1_rx_pe2_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_2, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_2, (B91_FUNC_B | B91_PULL_UP))>;
 	};
 	uart1_rts_pe3_default: uart1_rts_pe3_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_3, B91_FUNC_B)>;
 	};
 	uart1_cts_pe1_default: uart1_cts_pe1_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_1, B91_FUNC_B)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_E, B9x_PIN_1, (B91_FUNC_B | B91_PULL_UP))>;
 	};
 
 	/* PWM Channel 0 (PB4) */

--- a/boards/riscv/tlsr9528a/tlsr9528a-pinctrl.dtsi
+++ b/boards/riscv/tlsr9528a/tlsr9528a-pinctrl.dtsi
@@ -18,13 +18,15 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_2, B92_FUNC_UART0_TX)>;
 	};
 	uart0_rx_pb3_default: uart0_rx_pb3_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3, B92_FUNC_UART0_RTX_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_3,
+				(B92_FUNC_UART0_RTX_IO | B92_PULL_UP))>;
 	};
 	uart0_rts_pb4_default: uart0_rts_pb4_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_4, B92_FUNC_UART0_RTS)>;
 	};
 	uart0_cts_pb6_default: uart0_cts_pb6_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6, B92_FUNC_UART0_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_B, B9x_PIN_6,
+				(B92_FUNC_UART0_CTS_I | B92_PULL_UP))>;
 	};
 
 	/* UART1: TX(PC6), RX(PC7), RTS(PC5), CTS(PC4) */
@@ -33,13 +35,15 @@
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_6, B92_FUNC_UART1_TX)>;
 	};
 	uart1_rx_pc7_default: uart1_rx_pc7_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7, B92_FUNC_UART1_RTX_IO)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_7,
+				(B92_FUNC_UART1_RTX_IO | B92_PULL_UP))>;
 	};
 	uart1_rts_pc5_default: uart1_rts_pc5_default {
 		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_5, B92_FUNC_UART1_RTS)>;
 	};
 	uart1_cts_pc4_default: uart1_cts_pc4_default {
-		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4, B92_FUNC_UART1_CTS_I)>;
+		pinmux = <B9x_PINMUX_SET(B9x_PORT_C, B9x_PIN_4,
+				(B92_FUNC_UART1_CTS_I | B92_PULL_UP))>;
 	};
 
 	/* PWM Channel 0 (PD0) */

--- a/drivers/serial/uart_b9x.c
+++ b/drivers/serial/uart_b9x.c
@@ -317,6 +317,12 @@ static int uart_b9x_driver_init(const struct device *dev)
 	const struct uart_b9x_config *cfg = dev->config;
 	struct uart_b9x_data *data = dev->data;
 
+	/* configure pins */
+	status = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (status < 0) {
+		return status;
+	}
+
 	/* Reset Tx, Rx status before usage */
 #if CONFIG_SOC_RISCV_TELINK_B91
 	uart->status |= UART_RX_RESET_BIT | UART_TX_RESET_BIT;
@@ -325,12 +331,6 @@ static int uart_b9x_driver_init(const struct device *dev)
 #endif
 	data->rx_byte_index = 0;
 	data->tx_byte_index = 0;
-
-	/* configure pins */
-	status = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-	if (status < 0) {
-		return status;
-	}
 
 	uart_b9x_cal_div_and_bwpc(cfg->baud_rate, sys_clk.pclk * 1000 * 1000, &divider, &bwpc);
 	uart_b9x_init(uart, divider, bwpc, UART_PARITY_NONE, UART_STOP_BIT_1);
@@ -589,6 +589,55 @@ static void uart_b9x_irq_callback_set(const struct device *dev,
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
+#ifdef CONFIG_UART_DRV_CMD
+#include <gpio.h>
+
+int uart_b9x_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
+{
+	int result = -ENOTSUP;
+
+	if (cmd == 0) {
+		/* finish transmission */
+		volatile struct uart_b9x_t *uart = GET_UART(dev);
+
+		k_sched_lock();
+		while (uart_b9x_get_tx_bufcnt(uart) >= UART_TX_BUF_CNT) {
+		}
+#if CONFIG_SOC_RISCV_TELINK_B91
+		while (!(uart->txrx_status & FLD_UART_TX_DONE)) {
+		}
+#elif CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
+		while (!(uart->txrx_status & FLD_UART_TXDONE_IRQ)) {
+		}
+#endif
+		/* CMD 0: Get logical zero level UART pins count */
+		ARG_UNUSED(p);
+		const struct uart_b9x_config *cfg = dev->config;
+		const struct pinctrl_dev_config *pcfg = cfg->pcfg;
+
+		result = 0;
+		for (uint8_t i = 0; i < pcfg->state_cnt; i++) {
+			const struct pinctrl_state *state = &pcfg->states[i];
+
+			if (state->id == PINCTRL_STATE_DEFAULT) {
+				for (uint8_t j = 0; j < state->pin_cnt; j++) {
+					const pinctrl_soc_pin_t *pin = &state->pins[j];
+					bool level = gpio_get_level(B9x_PINMUX_GET_PIN(*pin));
+
+					if (!level) {
+						result++;
+					}
+				}
+				break;
+			}
+		}
+		k_sched_unlock();
+	}
+
+	return result;
+}
+#endif /* CONFIG_UART_DRV_CMD */
+
 #ifdef CONFIG_PM_DEVICE
 
 static int uart_b9x_pm_action(const struct device *dev, enum pm_device_action action)
@@ -650,6 +699,9 @@ static const struct uart_driver_api uart_b9x_driver_api = {
 	.irq_is_pending = uart_b9x_irq_is_pending,
 	.irq_update = uart_b9x_irq_update,
 	.irq_callback_set = uart_b9x_irq_callback_set,
+#endif
+#ifdef CONFIG_UART_DRV_CMD
+	.drv_cmd = uart_b9x_drv_cmd,
 #endif
 };
 

--- a/include/zephyr/dt-bindings/pinctrl/b91-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/b91-pinctrl.h
@@ -62,6 +62,10 @@
 #define B9x_PIN_MSK      0xFFFF
 #define B9x_PIN_ID_MSK   0xFF
 
+#define B91_PULL_NONE    (B9x_PULL_NONE << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B91_PULL_DOWN    (B9x_PULL_DOWN << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B91_PULL_UP      (B9x_PULL_UP << (B9x_PULL_POS - B9x_FUNC_POS))
+
 /* Setters and getters */
 
 #define B9x_PINMUX_SET(port, pin, func)   ((func << B9x_FUNC_POS) | \

--- a/include/zephyr/dt-bindings/pinctrl/b92-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/b92-pinctrl.h
@@ -128,6 +128,10 @@
 #define B9x_PIN_MSK      0xFFFF
 #define B9x_PIN_ID_MSK   0xFF
 
+#define B92_PULL_NONE    (B9x_PULL_NONE << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B92_PULL_DOWN    (B9x_PULL_DOWN << (B9x_PULL_POS - B9x_FUNC_POS))
+#define B92_PULL_UP      (B9x_PULL_UP << (B9x_PULL_POS - B9x_FUNC_POS))
+
 /* Setters and getters */
 
 #define B9x_PINMUX_SET(port, pin, func)   ((func << B9x_FUNC_POS) | \

--- a/scripts/west_commands/runners/bdt_tool.py
+++ b/scripts/west_commands/runners/bdt_tool.py
@@ -51,14 +51,18 @@ class BDTBinaryRunner(ZephyrBinaryRunner):
         build_conf = BuildConfiguration(self.cfg.build_dir)
         # get chip
         soc_type = None
-        if build_conf['CONFIG_SOC_RISCV_TELINK_TL321X']:
-            soc_type = 'TL321X'
-        if build_conf['CONFIG_SOC_RISCV_TELINK_B95']:
-            soc_type = 'B95'
-        if build_conf['CONFIG_SOC_RISCV_TELINK_B92']:
-            soc_type = 'B92'
-        if build_conf['CONFIG_SOC_RISCV_TELINK_B91']:
-            soc_type = '9518'
+        if 'CONFIG_SOC_RISCV_TELINK_TL321X' in build_conf:
+            if build_conf['CONFIG_SOC_RISCV_TELINK_TL321X']:
+                soc_type = 'TL321X'
+        if 'CONFIG_SOC_RISCV_TELINK_B95' in build_conf:
+            if build_conf['CONFIG_SOC_RISCV_TELINK_B95']:
+                soc_type = 'B95'
+        if 'CONFIG_SOC_RISCV_TELINK_B92' in build_conf:
+            if build_conf['CONFIG_SOC_RISCV_TELINK_B92']:
+                soc_type = 'B92'
+        if 'CONFIG_SOC_RISCV_TELINK_B91' in build_conf:
+            if build_conf['CONFIG_SOC_RISCV_TELINK_B91']:
+                soc_type = '9518'
         if soc_type is None:
             print('only Telink chips are supported!')
             exit()

--- a/soc/riscv/riscv-privilege/telink_b9x/Kconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b9x/Kconfig.series
@@ -32,6 +32,8 @@ config SOC_SERIES_RISCV_TELINK_B9X_NON_RETENTION_RAM_CODE
 config TELINK_B9X_MCUBOOT_STARTUP
 	bool "Telink B9x MCUBoot startup handler"
 	depends on SOC_SERIES_RISCV_TELINK_B9X && MCUBOOT
+	select CRC
+	select UART_DRV_CMD
 	help
 	  Run Telink specific vendor code before MCUBoot
 	  main process


### PR DESCRIPTION
- apply pull-up to UART input pins
- since there is no UART API which reliable detects UART break condition GPIO is used instead of it (low line level). Added vendor API which counts logical low UART lines level.