### PR TITLE
telink: Finish UART transmission during pins reading

### DIFF
--- a/drivers/serial/uart_b9x.c
+++ b/drivers/serial/uart_b9x.c
@@ -600,6 +600,19 @@ int uart_b9x_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
 	int result = -ENOTSUP;
 
 	if (cmd == 0) {
+		/* finish transmission */
+		volatile struct uart_b9x_t *uart = GET_UART(dev);
+
+		k_sched_lock();
+		while (uart_b9x_get_tx_bufcnt(uart)) {
+		}
+#if CONFIG_SOC_RISCV_TELINK_B91
+		while (!(uart->txrx_status & FLD_UART_TX_DONE)) {
+		}
+#elif CONFIG_SOC_RISCV_TELINK_B92 || CONFIG_SOC_RISCV_TELINK_B95
+		while (!(uart->txrx_status & FLD_UART_TXDONE_IRQ)) {
+		}
+#endif
 		/* CMD 0: Get logical zero level UART pins count */
 		ARG_UNUSED(p);
 		const struct uart_b9x_config *cfg = dev->config;
@@ -621,6 +634,7 @@ int uart_b9x_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
 				break;
 			}
 		}
+		k_sched_unlock();
 	}
 
 	return result;

--- a/drivers/serial/uart_tlx.c
+++ b/drivers/serial/uart_tlx.c
@@ -580,6 +580,16 @@ int uart_tlx_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
 	int result = -ENOTSUP;
 
 	if (cmd == 0) {
+		/* finish transmission */
+		volatile struct uart_tlx_t *uart = GET_UART(dev);
+
+		k_sched_lock();
+		while (uart_tlx_get_tx_bufcnt(uart)) {
+		}
+#if CONFIG_SOC_RISCV_TELINK_TL721X || CONFIG_SOC_RISCV_TELINK_TL321X
+		while (!(uart->txrx_status & FLD_UART_TXDONE_IRQ)) {
+		}
+#endif
 		/* CMD 0: Get logical zero level UART pins count */
 		ARG_UNUSED(p);
 		const struct uart_tlx_config *cfg = dev->config;
@@ -601,6 +611,7 @@ int uart_tlx_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
 				break;
 			}
 		}
+		k_sched_unlock();
 	}
 
 	return result;


### PR DESCRIPTION
To have clear UART pins levels all UART transmit operations should be finished. Additionally scheduler is locked to ensure that more priority task won't interrupt process of pins reading.