### PR TITLE
telink: B92&TL321X: add exit latency mechanism.

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -15,6 +15,12 @@
 #include <ksched.h>
 #include <kswap.h>
 
+#if defined(CONFIG_BT_B9X) && defined(CONFIG_SOC_RISCV_TELINK_B92)
+	#include "b9x_bt.h"
+#elif defined(CONFIG_BT_TLX) && defined(CONFIG_SOC_RISCV_TELINK_TL321X)
+	#include "tlx_bt.h"
+#endif
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 void z_pm_save_idle_exit(void)
@@ -81,9 +87,18 @@ void idle(void *unused1, void *unused2, void *unused3)
 		 * which is essential for the kernel's scheduling
 		 * logic.
 		 */
-		if (k_is_pre_kernel() || !pm_system_suspend(_kernel.idle)) {
+# if (defined(CONFIG_BT_B9X) && defined(CONFIG_SOC_RISCV_TELINK_B92) || \
+	 defined(CONFIG_BT_TLX) && defined(CONFIG_SOC_RISCV_TELINK_TL321X))
+		extern uint32_t blc_ll_checkBleRfFsmIsBusy(void);
+
+		if (blc_ll_checkBleRfFsmIsBusy() && tl_bt_controller_state()) {
 			k_cpu_idle();
-		}
+		} else
+#endif
+
+			if (k_is_pre_kernel() || !pm_system_suspend(_kernel.idle)) {
+				k_cpu_idle();
+			}
 #else
 		k_cpu_idle();
 #endif

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 14f11fc384682dbda2ad50c8c3befa99fb181b1a
+      revision: 1142dcd2f084d021cebf6a137320bda038ca4eb5
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- add suspend & deepretn exit latency mechanism to avoid BLE disconn issue.

Signed-off-by: Zhihan Tao <zhihan.tao@telink-semi.com>