### PR TITLE
telink: B92: add exit latency mechanism.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 359564ebb09bf384b1d3d017cc06250052d813c6
+      revision: cc7398accd3f47efef2e2116d3c48ec1acff0eb9
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- add suspend & deepretn exit latency mechanism to avoid BLE disconn issue.