### PR TITLE
boards: telink: tlsr9528a-common.dtsi Fix B92 GPIO

### DIFF
--- a/boards/telink/tlsr9258a/tlsr9258a-common.dtsi
+++ b/boards/telink/tlsr9258a/tlsr9258a-common.dtsi
@@ -186,7 +186,7 @@
 };
 
 &gpiod {
-	interrupts = <37 1>;
+	interrupts = <25 1>;
 	status = "okay";
 };
 
@@ -195,7 +195,7 @@
 };
 
 &gpiof {
-	interrupts = <38 1>;
+	interrupts = <26 1>;
 	status = "okay";
 };
 

--- a/boards/telink/tlsr9528a/tlsr9528a-common.dtsi
+++ b/boards/telink/tlsr9528a/tlsr9528a-common.dtsi
@@ -186,7 +186,7 @@
 };
 
 &gpiod {
-	interrupts = <37 1>;
+	interrupts = <25 1>;
 	status = "okay";
 };
 
@@ -195,7 +195,7 @@
 };
 
 &gpiof {
-	interrupts = <38 1>;
+	interrupts = <26 1>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Fix default GPIO ISR number to pass test using sample samples/basic/button/ without any modifications.