### PR TITLE
drivers: ieee802154: b9x/tlx: avoid duplicate encryption during retx.

### DIFF
--- a/drivers/ieee802154/ieee802154_b9x.c
+++ b/drivers/ieee802154/ieee802154_b9x.c
@@ -1127,6 +1127,11 @@ static int b9x_tx(const struct device *dev,
 
 	do {
 
+		if (net_pkt_ieee802154_mac_hdr_rdy(pkt)) {
+			LOG_WRN("The packet is encrypted and sent directly\n");
+			break;
+		}
+
 		net_pkt_set_ieee802154_frame_secured(pkt, false);
 		net_pkt_set_ieee802154_mac_hdr_rdy(pkt, false);
 

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -1125,6 +1125,11 @@ static int tlx_tx(const struct device *dev,
 
 	do {
 
+		if (net_pkt_ieee802154_mac_hdr_rdy(pkt)) {
+			LOG_WRN("The packet is encrypted and sent directly\n");
+			break;
+		}
+
 		net_pkt_set_ieee802154_frame_secured(pkt, false);
 		net_pkt_set_ieee802154_mac_hdr_rdy(pkt, false);
 


### PR DESCRIPTION
- Check the mIsHeaderUpdated flag before sending.
- If true, skip encryption.