### PR TITLE
telink: tlx: apply tlx optimization to zephyr v3.7

### DIFF
--- a/drivers/ieee802154/Kconfig.tlx
+++ b/drivers/ieee802154/Kconfig.tlx
@@ -48,6 +48,13 @@ config IEEE802154_TLX_DELAY_TRX_ACC
 	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
 	  or delayed reception), in ppm.
 
+config IEEE802154_TLX_OPTIMIZATION
+	bool "optimize the rf performance for tlx"
+	default n
+	help
+	  optimize the rf performance for tlx.
+
+
 if IEEE802154_TLX_MAC_STATIC
 
 config IEEE802154_TLX_MAC4

--- a/drivers/ieee802154/Kconfig.tlx
+++ b/drivers/ieee802154/Kconfig.tlx
@@ -49,10 +49,10 @@ config IEEE802154_TLX_DELAY_TRX_ACC
 	  or delayed reception), in ppm.
 
 config IEEE802154_TLX_OPTIMIZATION
-	bool "optimize the rf performance for tlx"
+	bool "Optimize 802.15.4 RF performance for TLX SoCs"
 	default n
 	help
-	  optimize the rf performance for tlx.
+	  Improve RF performance in IEEE 802.15.4 communication on TLX SoCs.
 
 
 if IEEE802154_TLX_MAC_STATIC

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -61,11 +61,11 @@ static struct tlx_enh_ack_table enh_ack_table;
 static struct tlx_mac_keys mac_keys;
 #endif
 #if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
-__attribute__((section(".bss")))  uint8_t rxpkt_buffer[TLX_TRX_LENGTH] = {0};
-__attribute__((section(".bss")))  uint8_t txpkt_buffer[TLX_TRX_LENGTH] = {0};
+__attribute__((section(".bss"))) uint8_t rxpkt_buffer[TLX_TRX_LENGTH] = {0};
+__attribute__((section(".bss"))) uint8_t txpkt_buffer[TLX_TRX_LENGTH] = {0};
 #endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 /* TLX data structure */
-static struct  tlx_data data = {
+static struct tlx_data data = {
 #ifdef CONFIG_OPENTHREAD_FTD
 	.src_match_table = &src_match_table,
 #endif /* CONFIG_OPENTHREAD_FTD */
@@ -73,7 +73,7 @@ static struct  tlx_data data = {
 	.enh_ack_table = &enh_ack_table,
 #endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
-/* mac keys data */
+	/* mac keys data */
 	.mac_keys = &mac_keys,
 #endif
 
@@ -679,7 +679,6 @@ static void ALWAYS_INLINE tlx_rf_rx_isr(const struct device *dev)
 		}
 		uint8_t *payload = (tlx->rx_buffer + TLX_PAYLOAD_OFFSET);
 
-
 		if (IS_ENABLED(CONFIG_IEEE802154_RAW_MODE) ||
 			IS_ENABLED(CONFIG_NET_L2_OPENTHREAD)) {
 			tlx_ieee802154_frame_parse(payload, length - TLX_FCS_LENGTH, &frame);
@@ -1006,7 +1005,7 @@ _attribute_ram_code_sec_ void stimer_rf_handler(const void *param)
 		stimer_clr_irq_status(FLD_SYSTEM_IRQ);
 	}
 }
-#endif /* CONFIG_IEEE802154_TLX_OPTIMIZATION */
+#endif
 
 /* API implementation: start */
 static int tlx_start(const struct device *dev)
@@ -1067,11 +1066,11 @@ static int tlx_stop(const struct device *dev)
 		riscv_plic_irq_disable(DT_INST_IRQN(0));
 		rf_set_tx_rx_off();
 #ifdef CONFIG_PM_DEVICE
-	/* Reset Radio */
-	rf_radio_reset();
+		/* Reset Radio */
+		rf_radio_reset();
 #if CONFIG_SOC_RISCV_TELINK_TL321X || CONFIG_SOC_RISCV_TELINK_TL721X
-	rf_reset_dma();
-	rf_baseband_reset();
+		rf_reset_dma();
+		rf_baseband_reset();
 #endif
 		tlx_rf_zigbee_250K_mode = false;
 #endif /* CONFIG_PM_DEVICE */
@@ -1302,10 +1301,10 @@ static int tlx_tx(const struct device *dev,
 #if defined CONFIG_IEEE802154_TLX_OPTIMIZATION && CONFIG_IEEE802154_TLX_OPTIMIZATION
 	if (isThreadCommissioned == true) {
 		irq_connect_dynamic(IRQ_SYSTIMER + CONFIG_2ND_LVL_ISR_TBL_OFFSET, 2,
-				stimer_rf_handler, 0, 0);
+				    stimer_rf_handler, 0, 0);
 		plic_interrupt_disable(IRQ_SYSTIMER);
-		stimer_set_irq_capture(stimer_get_tick()
-				+ TLX_TX_WAIT_TIME_MS*SYSTEM_TIMER_TICK_1MS);
+		stimer_set_irq_capture(stimer_get_tick() +
+				       TLX_ACK_WAIT_TIME_MS * SYSTEM_TIMER_TICK_1MS);
 		stimer_clr_irq_status(FLD_SYSTEM_IRQ);
 		stimer_set_irq_mask(FLD_SYSTEM_IRQ_MASK);
 		plic_interrupt_enable(IRQ_SYSTIMER);
@@ -1323,23 +1322,23 @@ static int tlx_tx(const struct device *dev,
 		tlx->ack_sn = frag->data[IEEE802154_FRAME_LENGTH_FCF];
 		tlx->ack_handler_en = true;
 #if defined CONFIG_IEEE802154_TLX_OPTIMIZATION && CONFIG_IEEE802154_TLX_OPTIMIZATION
-	if (isThreadCommissioned == true) {
-		plic_interrupt_disable(IRQ_SYSTIMER);
-		stimer_clr_irq_status(FLD_SYSTEM_IRQ);
-		stimer_set_irq_capture(stimer_get_tick()
-				+TLX_ACK_WAIT_TIME_MS*SYSTEM_TIMER_TICK_1MS);
-		plic_interrupt_enable(IRQ_SYSTIMER);
-		core_entry_wfi_mode();
-		if (k_sem_take(&tlx->ack_wait, K_MSEC(0)) != 0) {
-			status = -ENOMSG;
-		}
-	} else
+		if (isThreadCommissioned == true) {
+			plic_interrupt_disable(IRQ_SYSTIMER);
+			stimer_clr_irq_status(FLD_SYSTEM_IRQ);
+			stimer_set_irq_capture(stimer_get_tick() +
+					       TLX_ACK_WAIT_TIME_MS * SYSTEM_TIMER_TICK_1MS);
+			plic_interrupt_enable(IRQ_SYSTIMER);
+			core_entry_wfi_mode();
+			if (k_sem_take(&tlx->ack_wait, K_MSEC(0)) != 0) {
+				status = -ENOMSG;
+			}
+		} else
 #endif /* CONFIG_IEEE802154_TLX_OPTIMIZATION */
-	{
-		if (k_sem_take(&tlx->ack_wait, K_MSEC(TLX_ACK_WAIT_TIME_MS)) != 0) {
-			status = -ENOMSG;
+		{
+			if (k_sem_take(&tlx->ack_wait, K_MSEC(TLX_ACK_WAIT_TIME_MS)) != 0) {
+				status = -ENOMSG;
+			}
 		}
-	}
 		tlx->ack_handler_en = false;
 	}
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -6,11 +6,12 @@
 
 #define DT_DRV_COMPAT telink_tlx_zb
 
-#if CONFIG_SOC_RISCV_TELINK_TL721X || CONFIG_SOC_RISCV_TELINK_TL321X
 #include "rf_common.h"
-#endif
 #include "stimer.h"
 #include "tl_rf_power.h"
+#include "gpio.h"
+#include "plic.h"
+#include "clock.h"
 
 #define LOG_MODULE_NAME ieee802154_tlx
 #if defined(CONFIG_IEEE802154_DRIVER_LOG_LEVEL)
@@ -59,7 +60,10 @@ static struct tlx_enh_ack_table enh_ack_table;
 /* mac keys data */
 static struct tlx_mac_keys mac_keys;
 #endif
-
+#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+__attribute__((section(".bss")))  uint8_t rxpkt_buffer[TLX_TRX_LENGTH] = {0};
+__attribute__((section(".bss")))  uint8_t txpkt_buffer[TLX_TRX_LENGTH] = {0};
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 /* TLX data structure */
 static struct  tlx_data data = {
 #ifdef CONFIG_OPENTHREAD_FTD
@@ -72,6 +76,11 @@ static struct  tlx_data data = {
 /* mac keys data */
 	.mac_keys = &mac_keys,
 #endif
+
+#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+	.rx_buffer = rxpkt_buffer,
+	.tx_buffer = txpkt_buffer,
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 };
 
 #ifdef CONFIG_OPENTHREAD_FTD
@@ -627,14 +636,14 @@ static void ALWAYS_INLINE tlx_rf_rx_isr(const struct device *dev)
 	struct tlx_data *tlx = dev->data;
 	int status = -EINVAL;
 	struct net_pkt *pkt = NULL;
+	struct ieee802154_frame frame = {};
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP) && defined(CONFIG_NET_PKT_TXTIME)
 	uint64_t rx_time = k_ticks_to_us_near64(k_uptime_ticks());
 #if CONFIG_SOC_RISCV_TELINK_TL321X
 	uint32_t delta_time = (stimer_get_tick() - ZB_RADIO_TIMESTAMP_GET(tlx->rx_buffer)) /
 		SYSTEM_TIMER_TICK_1US;
-#endif
-#if CONFIG_SOC_RISCV_TELINK_TL721X
+#elif CONFIG_SOC_RISCV_TELINK_TL721X
 	uint32_t delta_time = (rf_bb_timer_get_tick() - ZB_RADIO_TIMESTAMP_GET(tlx->rx_buffer)) /
 		BB_TIMER_TICK_1US;
 #endif
@@ -669,7 +678,7 @@ static void ALWAYS_INLINE tlx_rf_rx_isr(const struct device *dev)
 			break;
 		}
 		uint8_t *payload = (tlx->rx_buffer + TLX_PAYLOAD_OFFSET);
-		struct ieee802154_frame frame;
+
 
 		if (IS_ENABLED(CONFIG_IEEE802154_RAW_MODE) ||
 			IS_ENABLED(CONFIG_NET_L2_OPENTHREAD)) {
@@ -813,6 +822,7 @@ static ALWAYS_INLINE void tlx_rf_tx_isr(const struct device *dev)
 {
 	struct tlx_data *tlx = dev->data;
 
+	plic_interrupt_disable(IRQ_SYSTIMER);
 	/* clear irq status */
 	rf_clr_irq_status(FLD_RF_IRQ_TX);
 
@@ -858,6 +868,7 @@ static int tlx_init(const struct device *dev)
 	tlx->is_started = false;
 	tlx->ack_handler_en = false;
 	tlx->ack_sending = false;
+	tlx->rf_mode_154 = false;
 	tlx->current_channel = TLX_TX_CH_NOT_SET;
 	tlx->current_dbm = TLX_TX_PWR_NOT_SET;
 #ifdef CONFIG_OPENTHREAD_FTD
@@ -934,8 +945,6 @@ static int tlx_set_channel(const struct device *dev, uint16_t channel)
 		tlx->current_channel = channel;
 		if (tlx->is_started) {
 			rf_set_chn(TLX_LOGIC_CHANNEL_TO_PHYSICAL(channel));
-			rf_set_txmode();
-			rf_set_rxmode();
 		}
 	}
 
@@ -987,6 +996,17 @@ static int tlx_set_txpower(const struct device *dev, int16_t dbm)
 }
 
 volatile bool tlx_rf_zigbee_250K_mode;
+#if defined CONFIG_IEEE802154_TLX_OPTIMIZATION && CONFIG_IEEE802154_TLX_OPTIMIZATION
+extern bool isThreadCommissioned;
+
+_attribute_ram_code_sec_ void stimer_rf_handler(const void *param)
+{
+	(void)param;
+	if (stimer_get_irq_status(FLD_SYSTEM_IRQ)) {
+		stimer_clr_irq_status(FLD_SYSTEM_IRQ);
+	}
+}
+#endif /* CONFIG_IEEE802154_TLX_OPTIMIZATION */
 
 /* API implementation: start */
 static int tlx_start(const struct device *dev)
@@ -1007,6 +1027,11 @@ static int tlx_start(const struct device *dev)
 			ske_dig_en();
 #endif
 #endif
+			if (tlx->rf_mode_154 == false) {
+				rf_baseband_reset();
+				rf_reset_dma();
+				tlx->rf_mode_154 = true;
+			}
 			rf_mode_init();
 			rf_set_zigbee_250K_mode();
 			tlx_rf_zigbee_250K_mode = true;
@@ -1021,8 +1046,6 @@ static int tlx_start(const struct device *dev)
 		}
 		rf_set_irq_mask(FLD_RF_IRQ_RX | FLD_RF_IRQ_TX);
 		riscv_plic_irq_enable(DT_INST_IRQN(0));
-		rf_set_txmode();
-		rf_set_rxmode();
 		tlx->is_started = true;
 	}
 
@@ -1044,11 +1067,11 @@ static int tlx_stop(const struct device *dev)
 		riscv_plic_irq_disable(DT_INST_IRQN(0));
 		rf_set_tx_rx_off();
 #ifdef CONFIG_PM_DEVICE
-#if CONFIG_SOC_RISCV_TELINK_TL321X
-		rf_baseband_reset();
-		rf_reset_dma();
-#elif CONFIG_SOC_RISCV_TELINK_TL721X
-		rf_radio_reset();
+	/* Reset Radio */
+	rf_radio_reset();
+#if CONFIG_SOC_RISCV_TELINK_TL321X || CONFIG_SOC_RISCV_TELINK_TL721X
+	rf_reset_dma();
+	rf_baseband_reset();
 #endif
 		tlx_rf_zigbee_250K_mode = false;
 #endif /* CONFIG_PM_DEVICE */
@@ -1276,8 +1299,19 @@ static int tlx_tx(const struct device *dev,
 	if (tlx->event_handler) {
 		tlx->event_handler(dev, IEEE802154_EVENT_TX_STARTED, (void *)frag);
 	}
-
-	/* wait for tx done */
+#if defined CONFIG_IEEE802154_TLX_OPTIMIZATION && CONFIG_IEEE802154_TLX_OPTIMIZATION
+	if (isThreadCommissioned == true) {
+		irq_connect_dynamic(IRQ_SYSTIMER + CONFIG_2ND_LVL_ISR_TBL_OFFSET, 2,
+				stimer_rf_handler, 0, 0);
+		plic_interrupt_disable(IRQ_SYSTIMER);
+		stimer_set_irq_capture(stimer_get_tick()
+				+ TLX_TX_WAIT_TIME_MS*SYSTEM_TIMER_TICK_1MS);
+		stimer_clr_irq_status(FLD_SYSTEM_IRQ);
+		stimer_set_irq_mask(FLD_SYSTEM_IRQ_MASK);
+		plic_interrupt_enable(IRQ_SYSTIMER);
+		core_entry_wfi_mode();
+	}
+#endif /* CONFIG_IEEE802154_TLX_OPTIMIZATION */
 	if (k_sem_take(&tlx->tx_wait, K_MSEC(TLX_TX_WAIT_TIME_MS)) != 0) {
 		rf_set_rxmode();
 		status = -EIO;
@@ -1288,9 +1322,24 @@ static int tlx_tx(const struct device *dev,
 		IEEE802154_FRAME_FCF_ACK_REQ_ON) {
 		tlx->ack_sn = frag->data[IEEE802154_FRAME_LENGTH_FCF];
 		tlx->ack_handler_en = true;
+#if defined CONFIG_IEEE802154_TLX_OPTIMIZATION && CONFIG_IEEE802154_TLX_OPTIMIZATION
+	if (isThreadCommissioned == true) {
+		plic_interrupt_disable(IRQ_SYSTIMER);
+		stimer_clr_irq_status(FLD_SYSTEM_IRQ);
+		stimer_set_irq_capture(stimer_get_tick()
+				+TLX_ACK_WAIT_TIME_MS*SYSTEM_TIMER_TICK_1MS);
+		plic_interrupt_enable(IRQ_SYSTIMER);
+		core_entry_wfi_mode();
+		if (k_sem_take(&tlx->ack_wait, K_MSEC(0)) != 0) {
+			status = -ENOMSG;
+		}
+	} else
+#endif /* CONFIG_IEEE802154_TLX_OPTIMIZATION */
+	{
 		if (k_sem_take(&tlx->ack_wait, K_MSEC(TLX_ACK_WAIT_TIME_MS)) != 0) {
 			status = -ENOMSG;
 		}
+	}
 		tlx->ack_handler_en = false;
 	}
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)

--- a/drivers/ieee802154/ieee802154_tlx.h
+++ b/drivers/ieee802154/ieee802154_tlx.h
@@ -9,7 +9,7 @@
 
 /* Timeouts */
 #define TLX_TX_WAIT_TIME_MS                 (10)
-#define TLX_ACK_WAIT_TIME_MS                (10)
+#define TLX_ACK_WAIT_TIME_MS                (5)
 
 /* Received data parsing */
 #ifndef IEEE802154_FRAME_LENGTH_PANID
@@ -93,8 +93,13 @@ struct tlx_mac_keys {
 /* data structure */
 struct tlx_data {
 	uint8_t mac_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
+#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+	uint8_t *rx_buffer;
+	uint8_t *tx_buffer;
+#else
 	uint8_t rx_buffer[TLX_TRX_LENGTH] __aligned(4);
 	uint8_t tx_buffer[TLX_TRX_LENGTH] __aligned(4);
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 	struct net_if *iface;
 	struct k_sem tx_wait;
 	struct k_sem ack_wait;
@@ -103,6 +108,7 @@ struct tlx_data {
 	uint8_t filter_ieee_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
 	volatile bool is_started;
 	volatile bool ack_handler_en;
+	volatile bool rf_mode_154;
 	volatile uint8_t ack_sn;
 	uint16_t current_channel;
 	int16_t current_dbm;


### PR DESCRIPTION
add config IEEE802154_TLX_OPTIMIZATION
and modify radio reset functions
based on de86a258732b52709d8b4f701a55e00304bf72ad