### PR TITLE
soc: telink: soc_context.h Fix SOC context

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b9x/soc_context.h
+++ b/soc/riscv/riscv-privilege/telink_b9x/soc_context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Telink Semiconductor
+ * Copyright (c) 2021-2025 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,38 +11,31 @@
 
 /* Telink B91 specific registers. */
 #if defined(CONFIG_TELINK_B9X_PFT_ARCH) && defined(__riscv_dsp)
-	#define SOC_ESF_MEMBERS	\
-	uint32_t mxstatus;	\
-	uint32_t ucode		\
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad,	     \
-	0xdeadbaad
+	#define SOC_ESF_MEMBERS     \
+	uint32_t mxstatus;          \
+	uint32_t ucode              \
 
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->mxstatus = 0;		 \
-	(soc_context)->ucode = 0
+	#define SOC_ESF_INIT        \
+	0,                          \
+	0
 
 #elif defined(CONFIG_TELINK_B9X_PFT_ARCH)
-	#define SOC_ESF_MEMBERS	\
+
+	#define SOC_ESF_MEMBERS     \
 	uint32_t mxstatus
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad
-
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->mxstatus = 0
+	#define SOC_ESF_INIT        \
+	0
 
 #elif defined(__riscv_dsp)
 
-	#define SOC_ESF_MEMBERS	\
+	#define SOC_ESF_MEMBERS     \
 	uint32_t ucode
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad
+	#define SOC_ESF_INIT        \
+	0
 
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->ucode = 0
 #endif
 
 #endif  /* CONFIG_RISCV_SOC_CONTEXT_SAVE */

--- a/soc/riscv/riscv-privilege/telink_tlx/soc_context.h
+++ b/soc/riscv/riscv-privilege/telink_tlx/soc_context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Telink Semiconductor
+ * Copyright (c) 2023-2025 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,38 +11,31 @@
 
 /* Telink B91 specific registers. */
 #if defined(CONFIG_TELINK_TLX_PFT_ARCH) && defined(__riscv_dsp)
-	#define SOC_ESF_MEMBERS	\
-	uint32_t mxstatus;	\
-	uint32_t ucode		\
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad,	     \
-	0xdeadbaad
+	#define SOC_ESF_MEMBERS     \
+	uint32_t mxstatus;          \
+	uint32_t ucode              \
 
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->mxstatus = 0;		 \
-	(soc_context)->ucode = 0
+	#define SOC_ESF_INIT        \
+	0,                          \
+	0
 
 #elif defined(CONFIG_TELINK_TLX_PFT_ARCH)
-	#define SOC_ESF_MEMBERS	\
+
+	#define SOC_ESF_MEMBERS     \
 	uint32_t mxstatus
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad
-
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->mxstatus = 0
+	#define SOC_ESF_INIT        \
+	0
 
 #elif defined(__riscv_dsp)
 
-	#define SOC_ESF_MEMBERS	\
+	#define SOC_ESF_MEMBERS     \
 	uint32_t ucode
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad
+	#define SOC_ESF_INIT        \
+	0
 
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->ucode = 0
 #endif
 
 #endif  /* CONFIG_RISCV_SOC_CONTEXT_SAVE */

--- a/soc/riscv/riscv-privilege/telink_w91/soc_context.h
+++ b/soc/riscv/riscv-privilege/telink_w91/soc_context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Telink Semiconductor
+ * Copyright (c) 2023-2025 Telink Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,38 +11,31 @@
 
 /* Telink W91 specific registers. */
 #if defined(CONFIG_TELINK_W91_PFT_ARCH) && defined(__riscv_dsp)
-	#define SOC_ESF_MEMBERS	\
-	uint32_t mxstatus;	\
-	uint32_t ucode		\
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad,	     \
-	0xdeadbaad
+	#define SOC_ESF_MEMBERS     \
+	uint32_t mxstatus;          \
+	uint32_t ucode              \
 
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->mxstatus = 0;		 \
-	(soc_context)->ucode = 0
+	#define SOC_ESF_INIT        \
+	0,                          \
+	0
 
 #elif defined(CONFIG_TELINK_W91_PFT_ARCH)
-	#define SOC_ESF_MEMBERS	\
+
+	#define SOC_ESF_MEMBERS     \
 	uint32_t mxstatus
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad
-
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->mxstatus = 0
+	#define SOC_ESF_INIT        \
+	0
 
 #elif defined(__riscv_dsp)
 
-	#define SOC_ESF_MEMBERS	\
+	#define SOC_ESF_MEMBERS     \
 	uint32_t ucode
 
-	#define SOC_ESF_INIT \
-	0xdeadbaad
+	#define SOC_ESF_INIT        \
+	0
 
-	#define SOC_ESF_THREAD_INIT(soc_context) \
-	(soc_context)->ucode = 0
 #endif
 
 #endif  /* CONFIG_RISCV_SOC_CONTEXT_SAVE */


### PR DESCRIPTION
Fixed initial values for Telink specific SOC context. Default SOC context values should correspond to their registers reset values. Setting custom specific initial values leds to unpredictable SOC behavior.