### PR TITLE
soc: telink: telink_w9x: Get rid of DLM section

### DIFF
--- a/boards/riscv/tlsr9118bdk40d/tlsr9118bdk40d-common.dtsi
+++ b/boards/riscv/tlsr9118bdk40d/tlsr9118bdk40d-common.dtsi
@@ -58,7 +58,7 @@
 	};
 
 	chosen {
-/* Note: use RAM_DLM for ".ram_dlm" when a shared SRAM will be used for "zephyr,sram" */
+		/* zephyr,aux_ram = &sram; */
 		zephyr,sram = &ram_dlm;
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &flash_mspi;

--- a/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_w91/CMakeLists.txt
@@ -52,7 +52,7 @@ zephyr_ld_options(-fuse-ld=bfd)
 zephyr_compile_options_ifdef(CONFIG_TELINK_W91_HWDSP -mext-dsp)
 zephyr_compile_options_ifndef(CONFIG_RISCV_GP -mno-relax)
 zephyr_linker_sources(ROM_START SORT_KEY 0x0 init.ld)
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0 dlm.ld)
+zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0 ram_aux.ld)
 zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x1 ilm.ld)
 
 # Wrap allocator functions

--- a/soc/riscv/riscv-privilege/telink_w91/blocking_core/blocking.c
+++ b/soc/riscv/riscv-privilege/telink_w91/blocking_core/blocking.c
@@ -28,7 +28,7 @@ enum {
 	BLOCKING_CORE_ACTIVE_REQ_STATE,
 };
 
-static atomic_t __GENERIC_SECTION(.ram_dlm) blocking_state = BLOCKING_INVALID_STATE;
+static atomic_t __GENERIC_SECTION(.ram_code_data) blocking_state = BLOCKING_INVALID_STATE;
 static struct ipc_based_driver ipc_data;    /* ipc driver data part */
 
 /* API implementation: get Machine Timer value */

--- a/soc/riscv/riscv-privilege/telink_w91/ilm.ld
+++ b/soc/riscv/riscv-privilege/telink_w91/ilm.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(ram_code,,)
 	. = ALIGN(4);
 	*(.ram_code)
 	*(".ram_code.*")
+	*(.ram_code_data)
+	*(".ram_code_data.*")
 
 	PROVIDE (_RAM_CODE_VMA_END = .);
 	PROVIDE (_RAM_CODE_VMA_START = ADDR(ram_code));

--- a/soc/riscv/riscv-privilege/telink_w91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_w91/linker.ld
@@ -14,9 +14,9 @@
 MEMORY
 {
 	RAM_ILM      (rwx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(ram_ilm)),              LENGTH = DT_REG_SIZE(DT_NODELABEL(ram_ilm))
-
-#	Note: use RAM_DLM for ".ram_dlm" when a shared SRAM will be used for "zephyr,sram"
-#	RAM_DLM      (rwx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(ram_dlm)),              LENGTH = DT_REG_SIZE(DT_NODELABEL(ram_dlm))
+#if DT_HAS_CHOSEN(zephyr_aux_ram)
+	RAM_AUX      (rwx) : ORIGIN = DT_REG_ADDR(DT_CHOSEN(zephyr_aux_ram)),          LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_aux_ram))
+#endif /* DT_HAS_CHOSEN(zephyr_aux_ram) */
 }
 
 #include <zephyr/arch/riscv/common/linker.ld>

--- a/soc/riscv/riscv-privilege/telink_w91/ram_aux.ld
+++ b/soc/riscv/riscv-privilege/telink_w91/ram_aux.ld
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if DT_HAS_CHOSEN(zephyr_aux_ram)
+
+SECTION_DATA_PROLOGUE(data_aux,,)
+{
+	. = ALIGN(4);
+	*(.data_aux)
+	*(".data_aux.*")
+
+	PROVIDE (_DATA_AUX_VMA_END = .);
+	PROVIDE (_DATA_AUX_VMA_START = ADDR(data_aux));
+	PROVIDE (_DATA_AUX_LMA_START = LOADADDR(data_aux));
+} GROUP_DATA_LINK_IN(RAM_AUX, ROMABLE_REGION)
+
+SECTION_DATA_PROLOGUE(bss_aux,(NOLOAD),)
+{
+	. = ALIGN(4);
+	*(.bss_aux)
+	*(".bss_aux.*")
+
+	PROVIDE (_BSS_AUX_VMA_END = .);
+	PROVIDE (_BSS_AUX_VMA_START = ADDR(bss_aux));
+} GROUP_DATA_LINK_IN(RAM_AUX, RAM_AUX)
+
+#endif /* DT_HAS_CHOSEN(zephyr_aux_ram) */

--- a/soc/riscv/riscv-privilege/telink_w91/start.S
+++ b/soc/riscv/riscv-privilege/telink_w91/start.S
@@ -99,17 +99,31 @@ _start_n22:
 	li     t0, (1 << 6)
 	csrs   NDS_MMISC_CTL, t0                #/ Enable Misaligned access
 
-_RAM_DLM_INIT:
-	la     t1, _RAM_DLM_LMA_START
-	la     t2, _RAM_DLM_VMA_START
-	la     t3, _RAM_DLM_VMA_END
-_RAM_DLM_INIT_BEGIN:
-	bleu   t3, t2, _RAM_CODE_INIT
+#if DT_HAS_CHOSEN(zephyr_aux_ram)
+
+_DATA_AUX_INIT:
+	la     t1, _DATA_AUX_LMA_START
+	la     t2, _DATA_AUX_VMA_START
+	la     t3, _DATA_AUX_VMA_END
+_DATA_AUX_INIT_BEGIN:
+	bleu   t3, t2, _BSS_AUX_INIT
 	lw     t0, 0(t1)
 	sw     t0, 0(t2)
 	addi   t1, t1, 4
 	addi   t2, t2, 4
-	j      _RAM_DLM_INIT_BEGIN
+	j      _DATA_AUX_INIT_BEGIN
+
+_BSS_AUX_INIT:
+	lui    t0, 0
+	la     t2, _BSS_AUX_VMA_START
+	la     t3, _BSS_AUX_VMA_END
+_BSS_AUX_INIT_BEGIN:
+	bleu   t3, t2, _RAM_CODE_INIT
+	sw     t0, 0(t2)
+	addi   t2, t2, 4
+	j      _BSS_AUX_INIT_BEGIN
+
+#endif /* DT_HAS_CHOSEN(zephyr_aux_ram) */
 
 _RAM_CODE_INIT:
 	la     t1, _RAM_CODE_LMA_START


### PR DESCRIPTION
- Introduced auxiliary RAM (zephyr,aux_ram)
- Moved all blocking core to ILM