### PR TITLE
telink: tl3218x: fix gpio interrupts

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 8c7324c0283ad70daffb0daa8a9ef970ac2224b3
+      revision: fb182926db1a24f548e92ddea557843eb4d63b06
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- fix gpio interrupts in deep retention mode
- leave ram_code only to avoid section mis-matches