### PR TITLE
telink: telink_w9x: openthread: Enhanced-ack linkmetrics

### DIFF
--- a/soc/telink/tlsr/telink_w9x/ot_rcp/ot_rcp.c
+++ b/soc/telink/tlsr/telink_w9x/ot_rcp/ot_rcp.c
@@ -273,7 +273,8 @@ int openthread_rcp_reset(struct openthread_rcp_data *ot_rcp)
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -300,7 +301,8 @@ int openthread_rcp_ieee_eui64(struct openthread_rcp_data *ot_rcp, uint8_t ieee_e
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -328,7 +330,8 @@ int openthread_rcp_capabilities(struct openthread_rcp_data *ot_rcp,
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -355,7 +358,8 @@ int openthread_rcp_enable_src_match(struct openthread_rcp_data *ot_rcp, bool ena
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -382,7 +386,8 @@ int openthread_rcp_ack_fpb(struct openthread_rcp_data *ot_rcp, uint16_t addr, bo
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -409,7 +414,8 @@ int openthread_rcp_ack_fpb_ext(struct openthread_rcp_data *ot_rcp, uint8_t addr[
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -436,7 +442,8 @@ static int openthread_rcp_ack_fpb_short_clear(struct openthread_rcp_data *ot_rcp
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -463,7 +470,8 @@ static int openthread_rcp_ack_fpb_ext_clear(struct openthread_rcp_data *ot_rcp)
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -502,7 +510,8 @@ int openthread_rcp_mac_frame_counter(struct openthread_rcp_data *ot_rcp, uint32_
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -529,7 +538,8 @@ int openthread_rcp_panid(struct openthread_rcp_data *ot_rcp, uint16_t pan_id)
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -556,7 +566,8 @@ int openthread_rcp_short_addr(struct openthread_rcp_data *ot_rcp, uint16_t addr)
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -583,7 +594,8 @@ int openthread_rcp_ext_addr(struct openthread_rcp_data *ot_rcp, uint8_t addr[8])
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -610,7 +622,8 @@ int openthread_rcp_tx_power(struct openthread_rcp_data *ot_rcp, int8_t pwr_dbm)
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -637,7 +650,8 @@ int openthread_rcp_enable(struct openthread_rcp_data *ot_rcp, bool enable)
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -664,7 +678,8 @@ int openthread_rcp_receive_enable(struct openthread_rcp_data *ot_rcp, bool enabl
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -691,7 +706,8 @@ int openthread_rcp_channel(struct openthread_rcp_data *ot_rcp, uint8_t channel)
 				processed = true;
 				result = 0;
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}
@@ -730,7 +746,38 @@ int openthread_rcp_transmit(struct openthread_rcp_data *ot_rcp, struct spinel_fr
 					}
 				}
 			} else {
-				LOG_WRN("spinel trash received during %s", __func__);
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
+			}
+			free(response.data);
+		}
+	}
+
+	return result;
+}
+
+int openthread_rcp_link_metrics(struct openthread_rcp_data *ot_rcp, uint16_t short_addr,
+				const uint8_t ext_addr[8], struct spinel_link_metrics link_metrics)
+{
+	k_timepoint_t start_tp;
+	bool processed = false;
+	int result = spinel_drv_send_link_metrics(&ot_rcp->spinel_drv,
+						  openthread_rcp_spinel_transmission, ot_rcp,
+						  short_addr, ext_addr, link_metrics);
+
+	result = openthread_rcp_process_start(ot_rcp, result, &start_tp);
+	while (result >= 0 && !processed) {
+		struct openthread_rcp_buffer response;
+
+		result = openthread_rcp_process_continue(ot_rcp, start_tp, &response);
+		if (result >= 0) {
+			if (spinel_drv_check_link_metrics(&ot_rcp->spinel_drv, response.data,
+							  response.data_size)) {
+				processed = true;
+				result = 0;
+			} else {
+				LOG_HEXDUMP_WRN(response.data, response.data_size,
+						"trash rx @ " STRINGIFY(__LINE__));
 			}
 			free(response.data);
 		}

--- a/soc/telink/tlsr/telink_w9x/ot_rcp/ot_rcp.h
+++ b/soc/telink/tlsr/telink_w9x/ot_rcp/ot_rcp.h
@@ -59,5 +59,7 @@ int openthread_rcp_enable(struct openthread_rcp_data *ot_rcp, bool enable);
 int openthread_rcp_receive_enable(struct openthread_rcp_data *ot_rcp, bool enable);
 int openthread_rcp_channel(struct openthread_rcp_data *ot_rcp, uint8_t channel);
 int openthread_rcp_transmit(struct openthread_rcp_data *ot_rcp, struct spinel_frame_data *frame);
+int openthread_rcp_link_metrics(struct openthread_rcp_data *ot_rcp, uint16_t short_addr,
+				const uint8_t ext_addr[8], struct spinel_link_metrics link_metrics);
 
 #endif /* OPENTHREAD_RCP_H */

--- a/soc/telink/tlsr/telink_w9x/ot_rcp/spinel.h
+++ b/soc/telink/tlsr/telink_w9x/ot_rcp/spinel.h
@@ -17,6 +17,13 @@ enum spinel_reset_type {
 	SPINEL_RESET_BOOTLOADER = 3,
 };
 
+enum {
+	SPINEL_THREAD_LINK_METRIC_PDU_COUNT = (1 << 0),
+	SPINEL_THREAD_LINK_METRIC_LQI = (1 << 1),
+	SPINEL_THREAD_LINK_METRIC_LINK_MARGIN = (1 << 2),
+	SPINEL_THREAD_LINK_METRIC_RSSI = (1 << 3),
+};
+
 enum spinel_cmd {
 	SPINEL_CMD_NOOP = 0,
 

--- a/soc/telink/tlsr/telink_w9x/ot_rcp/spinel_drv.h
+++ b/soc/telink/tlsr/telink_w9x/ot_rcp/spinel_drv.h
@@ -38,6 +38,13 @@ struct spinel_frame_data {
 	};
 };
 
+struct spinel_link_metrics {
+	bool pdu_count: 1;
+	bool lqi: 1;
+	bool link_margin: 1;
+	bool rssi: 1;
+};
+
 struct spinel_t_id {
 	uint8_t act_id;
 	uint32_t props[SPINEL_MAX_NUMB_TID];
@@ -119,5 +126,10 @@ bool spinel_drv_check_transmit_frame(struct spinel_drv_data *spinel_drv, const u
 				     uint16_t data_size, struct spinel_frame_data *frame);
 bool spinel_drv_check_receive_frame(struct spinel_drv_data *spinel_drv, const uint8_t *data,
 				    uint16_t data_size, struct spinel_frame_data *frame);
+int spinel_drv_send_link_metrics(struct spinel_drv_data *spinel_drv, spinel_tx_cb tx_cb,
+				 const void *ctx, uint16_t short_addr, const uint8_t ext_addr[8],
+				 struct spinel_link_metrics link_metrics);
+bool spinel_drv_check_link_metrics(struct spinel_drv_data *spinel_drv, const uint8_t *data,
+				   uint16_t data_size);
 
 #endif /* SPINEL_DRV_H */


### PR DESCRIPTION
Linkmetrics enhanced-ack response.
To use, from other device in thread network:
ot linkmetrics mgmt <w91-ip-link-local-addr> enhanced-ack register [qmr]