### PR TITLE
telink: TL7218X: change macro SUSPEND_EXIT_LATENCY_US .

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 1ea83747404504da52daf10289bb275e18b60115
+      revision: d91dedb76c034b3e89f3942b495b5327c05db5e5
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- For 80MHz sysclk, change macro SUSPEND_EXIT_LATENCY_US form 250us to 150u.
- For 60MHz, SUSPEND_EXIT_LATENCY_US should be 250us.
- This parameter should be measured by ellisys bluetooth analyzer.
- A better solution should be proposed later.

Signed-off-by: Zhihan Tao <zhihan.tao@telink-semi.com>