### PR TITLE
fix heap overflow for amazon commissioning

### DIFF
--- a/soc/riscv/riscv-privilege/telink_b9x/soc.c
+++ b/soc/riscv/riscv-privilege/telink_b9x/soc.c
@@ -135,6 +135,13 @@ static int soc_b9x_init(void)
 #if CONFIG_SOC_RISCV_TELINK_B91
 	sys_init(POWER_MODE, VBAT_TYPE);
 #elif CONFIG_SOC_RISCV_TELINK_B92
+	/* Reset Radio */
+	rf_radio_reset();
+#if CONFIG_SOC_RISCV_TELINK_B91 || CONFIG_SOC_RISCV_TELINK_B92
+	rf_reset_dma();
+	rf_baseband_reset();
+#endif
+	rf_clr_irq_status(FLD_RF_IRQ_ALL);
 	sys_init(POWER_MODE, VBAT_TYPE, GPIO_VOLTAGE_3V3);
 #endif
 

--- a/soc/riscv/riscv-privilege/telink_tlx/soc.c
+++ b/soc/riscv/riscv-privilege/telink_tlx/soc.c
@@ -135,7 +135,13 @@ static int soc_tlx_init(void)
 	/* Select internal 32K for BLE PM, ASAP after boot */
 	blc_pm_select_internal_32k_crystal();
 #endif /* CONFIG_PM  */
-
+	/* Reset Radio */
+	rf_radio_reset();
+#if CONFIG_SOC_RISCV_TELINK_TL321X || CONFIG_SOC_RISCV_TELINK_TL721X
+	rf_reset_dma();
+	rf_baseband_reset();
+#endif
+	rf_clr_irq_status(FLD_RF_IRQ_ALL);
 	/* system init */
 	sys_init(POWER_MODE, VBAT_TYPE, INTERNAL_CAP_XTAL24M);
 


### PR DESCRIPTION
 - Clean the rf radio and dma register before sys_init.