### PR TITLE
drivers: hwinfo: add hw and sw reset cause support for tlx and b9x

### DIFF
--- a/drivers/hwinfo/hwinfo_b9x.c
+++ b/drivers/hwinfo/hwinfo_b9x.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/drivers/hwinfo.h>
+#include <ext_driver/ext_pm.h>
 #include <string.h>
 #include <flash.h>
 
@@ -26,8 +27,13 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	uint32_t flags = 0;
+	uint32_t reason = pm_get_mcu_status();
 
-	flags |= RESET_SOFTWARE;
+	if (reason & MCU_STATUS_POWER_ON) {
+		flags |= RESET_PIN;
+	} else {
+		flags |= RESET_SOFTWARE;
+	}
 
 	*cause = flags;
 
@@ -41,7 +47,7 @@ int z_impl_hwinfo_clear_reset_cause(void)
 
 int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 {
-	*supported = (RESET_SOFTWARE);
+	*supported = (RESET_PIN | RESET_SOFTWARE);
 
 	return 0;
 }

--- a/drivers/hwinfo/hwinfo_tlx.c
+++ b/drivers/hwinfo/hwinfo_tlx.c
@@ -5,8 +5,13 @@
  */
 
 #include <zephyr/drivers/hwinfo.h>
+#include <ext_driver/ext_pm.h>
 #include <string.h>
 #include <flash.h>
+
+extern void pm_update_status_info(unsigned char clr_en);
+
+static bool is_mcu_status_updated;
 
 #if CONFIG_SOC_RISCV_TELINK_TL721X
 #include <flash/flash_common.h>
@@ -34,9 +39,19 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 
 int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
-	uint32_t flags = 0;
+	if (!is_mcu_status_updated) {
+		pm_update_status_info(1);
+		is_mcu_status_updated = true;
+	}
 
-	flags |= RESET_SOFTWARE;
+	uint32_t flags = 0;
+	uint32_t reason = pm_get_mcu_status();
+
+	if (reason & MCU_STATUS_POWER_ON) {
+		flags |= RESET_PIN;
+	} else {
+		flags |= RESET_SOFTWARE;
+	}
 
 	*cause = flags;
 
@@ -50,7 +65,7 @@ int z_impl_hwinfo_clear_reset_cause(void)
 
 int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 {
-	*supported = (RESET_SOFTWARE);
+	*supported = (RESET_PIN | RESET_SOFTWARE);
 
 	return 0;
 }


### PR DESCRIPTION
Check mcu_status to know if the reset cause was hardware or software