### PR TITLE
telink: tlx: add module boards into CI

### DIFF
--- a/.github/workflows/telink-tl321x-build.yaml
+++ b/.github/workflows/telink-tl321x-build.yaml
@@ -129,6 +129,11 @@ jobs:
         cd ..
         west build -b tl3218x_retention        -d build_ot_echo_client_pm_deep_tl3218x    zephyr/samples/net/sockets/echo_client                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DOVERLAY_CONFIG=overlay-ot-sed.conf -DCONFIG_OPENTHREAD_NETWORKKEY=\"09:24:01:56:04:4a:45:0b:23:22:1e:0e:3b:0d:0e:61:2f:1b:2c:24\" -DCONFIG_PM=y -DCONFIG_SOC_SERIES_RISCV_TELINK_TLX_NON_RETENTION_RAM_CODE=y -DCONFIG_TELINK_TLX_2_WIRE_SPI_ENABLE=y
 
+    - name: Build TL321x_ml3m samples/basic/button
+      run: |
+        cd ..
+        west build -b tl3218x_ml3m -d build_button_tl321x_ml3m                zephyr/samples/basic/button                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
@@ -149,6 +154,7 @@ jobs:
         cp ../build_ot_coprocessor_rcp_usb_tl321x/zephyr/zephyr.bin     telink_build_artifacts/tl321x_ot_coprocessor_rcp_usb.bin
         cp ../build_crypto_mbedtls_tl321x/zephyr/zephyr.bin             telink_build_artifacts/tl321x_mbedtls.bin
         cp ../build_ot_echo_client_pm_deep_tl3218x/zephyr/zephyr.bin    telink_build_artifacts/tl321x_ot_echo_client_pm_retention.bin
+        cp ../build_button_tl321x_ml3m/zephyr/zephyr.bin                telink_build_artifacts/tl321x_ml3m_button.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/telink-tl321x-nds-build.yaml
+++ b/.github/workflows/telink-tl321x-nds-build.yaml
@@ -131,6 +131,11 @@ jobs:
         cd ..
         west build -b tl3218x_retention        -d build_ot_echo_client_pm_deep_tl3218x    zephyr/samples/net/sockets/echo_client                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DOVERLAY_CONFIG=overlay-ot-sed.conf -DCONFIG_OPENTHREAD_NETWORKKEY=\"09:24:01:56:04:4a:45:0b:23:22:1e:0e:3b:0d:0e:61:2f:1b:2c:24\" -DCONFIG_PM=y -DCONFIG_SOC_SERIES_RISCV_TELINK_TLX_NON_RETENTION_RAM_CODE=y -DCONFIG_TELINK_TLX_2_WIRE_SPI_ENABLE=y
 
+    - name: Build TL321x_ml3m samples/basic/button
+      run: |
+        cd ..
+        west build -b tl3218x_ml3m -d build_button_tl321x_ml3m                zephyr/samples/basic/button                   -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
@@ -151,6 +156,7 @@ jobs:
         cp ../build_ot_coprocessor_rcp_usb_tl321x/zephyr/zephyr.bin     telink_build_artifacts/tl321x_ot_coprocessor_rcp_usb.bin
         cp ../build_crypto_mbedtls_tl321x/zephyr/zephyr.bin             telink_build_artifacts/tl321x_mbedtls.bin
         cp ../build_ot_echo_client_pm_deep_tl3218x/zephyr/zephyr.bin    telink_build_artifacts/tl321x_ot_echo_client_pm_retention.bin
+        cp ../build_button_tl321x_ml3m/zephyr/zephyr.bin                telink_build_artifacts/tl321x_ml3m_button.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -135,6 +135,16 @@ jobs:
         cd ..
         west build -b tl7218x                  -d build_mcuboot_chip_id_tl721x          bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3
 
+    - name: Build TL721x_ml7g samples/basic/button
+      run: |
+        cd ..
+        west build -b tl7218x_ml7g             -d build_button_tl721x_ml7g              zephyr/samples/basic/button                              -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
+    - name: Build TL721x_ml7m samples/basic/button
+      run: |
+        cd ..
+        west build -b tl7218x_ml7m             -d build_button_tl721x_ml7m              zephyr/samples/basic/button                              -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
@@ -157,6 +167,8 @@ jobs:
         cp ../build_spi_flash_tl721x/zephyr/zephyr.bin                 telink_build_artifacts/tl721x_spi_flash.bin
         cp ../modules/hal/telink/zephyr/blobs/lib_zephyr_tl721x.a      telink_build_artifacts/lib_zephyr_tl721x.a
         cp ../build_mcuboot_chip_id_tl721x/zephyr/zephyr.bin           telink_build_artifacts/tl721x_mcuboot_chip_id.bin
+        cp ../build_button_tl721x_ml7g/zephyr/zephyr.bin               telink_build_artifacts/tl7218x_ml7g_button.bin
+        cp ../build_button_tl721x_ml7m/zephyr/zephyr.bin               telink_build_artifacts/tl7218x_ml7m_button.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/telink-tl721x-nds-build.yaml
+++ b/.github/workflows/telink-tl721x-nds-build.yaml
@@ -137,6 +137,16 @@ jobs:
         cd ..
         west build -b tl7218x                  -d build_mcuboot_chip_id_tl721x          bootloader/mcuboot/boot/zephyr                           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_LOG_DEFAULT_LEVEL=3
 
+    - name: Build TL721x_ml7g samples/basic/button
+      run: |
+        cd ..
+        west build -b tl7218x_ml7g             -d build_button_tl721x_ml7g              zephyr/samples/basic/button                              -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
+    - name: Build TL721x_ml7m samples/basic/button
+      run: |
+        cd ..
+        west build -b tl7218x_ml7m             -d build_button_tl721x_ml7m              zephyr/samples/basic/button                              -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
     - name: Collect artifacts
       run: |
         mkdir telink_build_artifacts
@@ -159,6 +169,8 @@ jobs:
         cp ../build_spi_flash_tl721x/zephyr/zephyr.bin                 telink_build_artifacts/tl721x_spi_flash.bin
         cp ../modules/hal/telink/zephyr/blobs/lib_zephyr_tl721x.a      telink_build_artifacts/lib_zephyr_tl721x.a
         cp ../build_mcuboot_chip_id_tl721x/zephyr/zephyr.bin           telink_build_artifacts/tl721x_mcuboot_chip_id.bin
+        cp ../build_button_tl721x_ml7g/zephyr/zephyr.bin               telink_build_artifacts/tl7218x_ml7g_button.bin
+        cp ../build_button_tl721x_ml7m/zephyr/zephyr.bin               telink_build_artifacts/tl7218x_ml7m_button.bin
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- add tl7218x modual board ml7g
- add tl7218x modual board ml7m
- add tl3218x modual board ml3m

compile command:
- `west build -b tl7218x_ml7g -d build_button_tl721x_ml7g zephyr/samples/basic/button -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y`
- `west build -b tl7218x_ml7m -d build_button_tl721x_ml7m zephyr/samples/basic/button -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y`
- `west build -b tl3218x_ml3m -d build_button_tl321x_ml3m zephyr/samples/basic/button -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y`