### PR TITLE
drivers: ieee802154: b9x/tlx: CCA Optimizations

### DIFF
--- a/drivers/ieee802154/ieee802154_b9x.c
+++ b/drivers/ieee802154/ieee802154_b9x.c
@@ -924,6 +924,7 @@ static int b9x_cca(const struct device *dev)
 	unsigned int t1 = stimer_get_tick();
 
 	rf_set_rxmode();
+	delay_us(85);
 	rssi_cur = rf_get_rssi();
 	rssiSum += rssi_cur;
 
@@ -934,7 +935,6 @@ static int b9x_cca(const struct device *dev)
 	}
 
 	rssi_peak = rssiSum/cnt;
-	rf_set_tx_rx_off();
 
 	if (rssi_peak > CONFIG_IEEE802154_B9X_CCA_RSSI_THRESHOLD) {
 		return -EBUSY;

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -943,6 +943,7 @@ static int tlx_cca(const struct device *dev)
 	unsigned int t1 = stimer_get_tick();
 
 	rf_set_rxmode();
+	delay_us(85);
 	rssi_cur = rf_get_rssi();
 	rssiSum += rssi_cur;
 


### PR DESCRIPTION
- After switching RF to RX state, add a delay to get a valid RSSI.
- Keep RF in RX state during CCA—don’t reset the radio module.