### PR TITLE
Update tl721x to Latest Hardware/BLE/Driver Version

### DIFF
--- a/boards/riscv/tl721x/tl7218x-common.dtsi
+++ b/boards/riscv/tl721x/tl7218x-common.dtsi
@@ -93,7 +93,9 @@
 
 		inp {
 			gpios = <&gpiod 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-				<&gpiod 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+				<&gpiod 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+				<&gpiod 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+				<&gpiod 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
 	};
 

--- a/drivers/adc/adc_tlx.c
+++ b/drivers/adc/adc_tlx.c
@@ -150,8 +150,10 @@ static signed short adc_tlx_get_code(void)
 {
 	signed short adc_code;
 
-#if  CONFIG_SOC_RISCV_TELINK_TL321X || CONFIG_SOC_RISCV_TELINK_TL721X
+#if  CONFIG_SOC_RISCV_TELINK_TL321X
 	adc_code = adc_get_code();
+#elif CONFIG_SOC_RISCV_TELINK_TL721X
+	adc_code = adc_get_raw_code();
 #endif
 	return adc_code;
 }
@@ -315,7 +317,7 @@ static int adc_tlx_channel_setup(const struct device *dev,
 		break;
 #elif CONFIG_SOC_RISCV_TELINK_TL721X
 	case 1200:
-		vref_internal_mv = ADC_VREF_VBAT_1P2V;
+		vref_internal_mv = ADC_VREF_ANTI_AGING;
 		break;
 #endif
 	default:

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -1063,7 +1063,11 @@ static int tlx_start(const struct device *dev)
 				rf_reset_dma();
 				tlx->rf_mode_154 = true;
 			}
+#if CONFIG_SOC_RISCV_TELINK_TL321X
 				rf_mode_init();
+#elif CONFIG_SOC_RISCV_TELINK_TL721X
+				rf_zigbee_mode_init();
+#endif
 				rf_set_zigbee_250K_mode();
 				tlx_rf_zigbee_250K_mode = true;
 		}
@@ -1104,7 +1108,7 @@ static int tlx_stop(const struct device *dev)
 	rf_reset_dma();
 	rf_baseband_reset();
 #endif
-		tlx_rf_zigbee_250K_mode = false;
+	tlx_rf_zigbee_250K_mode = false;
 #endif /* CONFIG_PM_DEVICE */
 		tlx->is_started = false;
 		if (tlx->event_handler) {

--- a/drivers/usb/device/usb_dc_tlx.c
+++ b/drivers/usb/device/usb_dc_tlx.c
@@ -5,7 +5,7 @@
  */
 
 #if CONFIG_SOC_RISCV_TELINK_TL721X
-#include "driver_tl721x.h"
+#include "driver.h"
 #elif CONFIG_SOC_RISCV_TELINK_TL321X
 #include "driver_tl321x.h"
 #endif

--- a/soc/riscv/riscv-privilege/telink_tlx/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_tlx/CMakeLists.txt
@@ -17,10 +17,6 @@ zephyr_sources(
 	sys_heap_alloc_wrap.c
 )
 
-zephyr_sources(
-	idle.c
-)
-
 zephyr_sources_ifdef(CONFIG_PM
 	power.c
 )

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 541f19515a7796411ed68352ffd9718472212ca6
+      revision: 82ac7118d5e966169dd7939580ad51988c2ce1bd
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
- update BLE libs to BLE release/V4.0.4.4
- apply changes in adc/usb due to driver API changes
- enable more buttons in key_pool
- revert default idle for tlx
- add and use rf_zigbee_mode_init for tl721x.