### PR TITLE
drivers: ieee802154: b9x/tlx: CCA Optimizations

### DIFF
--- a/drivers/ieee802154/Kconfig.tlx
+++ b/drivers/ieee802154/Kconfig.tlx
@@ -25,7 +25,7 @@ config IEEE802154_TLX_SET_TXRX_DELAY_US
 
 config IEEE802154_TLX_CCA_RSSI_THRESHOLD
 	int "CCA procedure RSSI threshold"
-	default -50
+	default -70
 	help
 	  CCA procedure returns true if the current RSSI value is less than
 	  this parameter.

--- a/drivers/ieee802154/ieee802154_b9x.c
+++ b/drivers/ieee802154/ieee802154_b9x.c
@@ -909,6 +909,7 @@ static int b9x_cca(const struct device *dev)
 	unsigned int t1 = stimer_get_tick();
 
 	rf_set_rxmode();
+	delay_us(85);
 	rssi_cur = rf_get_rssi();
 	rssiSum += rssi_cur;
 
@@ -919,7 +920,6 @@ static int b9x_cca(const struct device *dev)
 	}
 
 	rssi_peak = rssiSum/cnt;
-	rf_set_tx_rx_off();
 
 	if (rssi_peak > CONFIG_IEEE802154_B9X_CCA_RSSI_THRESHOLD) {
 		return -EBUSY;

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -919,15 +919,28 @@ static enum ieee802154_hw_caps tlx_get_capabilities(const struct device *dev)
 static int tlx_cca(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-
+	signed char rssi_peak = -110;
+	signed char rssi_cur = -110;
+	signed int rssiSum = 0;
+	signed int cnt = 1;
 	unsigned int t1 = stimer_get_tick();
 
-	while (!clock_time_exceed(t1, TLX_CCA_TIME_MAX_US)) {
-		if (rf_get_rssi() < CONFIG_IEEE802154_TLX_CCA_RSSI_THRESHOLD) {
-			return 0;
-		}
-	}
+	rf_set_rxmode();
+	delay_us(85);
+	rssi_cur = rf_get_rssi();
+	rssiSum += rssi_cur;
 
+	while (!clock_time_exceed(t1, TLX_CCA_TIME_MAX_US)) {
+		rssi_cur = rf_get_rssi();
+		rssiSum += rssi_cur;
+		cnt++;
+	}
+	rssi_peak = rssiSum/cnt;
+	if (rssi_peak > CONFIG_IEEE802154_TLX_CCA_RSSI_THRESHOLD) {
+		return -EBUSY;
+	} else {
+		return 0;
+	}
 	return -EBUSY;
 }
 


### PR DESCRIPTION
- After switching RF to RX state, add a delay to get a valid RSSI.
- Keep RF in RX state during CCA—don’t reset the radio module.
- Set TLX CCA RSSI Threshold to -70.