### PR TITLE
telink: kconfig: soc: provide a single config for ot rcp buffers

### DIFF
--- a/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
+++ b/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
@@ -22,12 +22,6 @@ config TELINK_OT_RCP_SYNC_TIME_OFFSET_MS
 	help
 		This option sets time to recalculate offset with RCP
 
-config TELINK_OT_RCP_RX_ISR_BUFFER_SIZE
-	int "Telink Openthread RCP UART RX ISR buffer size"
-	default 64
-	help
-		This option sets Telink Openthread RCP UART RX ISR buffer size.
-
 config TELINK_OT_RCP_BUFFER_SIZE
 	int "Telink Openthread RCP UART TX/RX buffer size"
 	default 256

--- a/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
+++ b/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
@@ -25,7 +25,7 @@ struct openthread_rcp_buffer {
 struct openthread_rcp_data {
 	const struct device *uart;
 	struct k_work work;
-	uint8_t rb_data[CONFIG_TELINK_OT_RCP_RX_ISR_BUFFER_SIZE];
+	uint8_t rb_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
 	struct ring_buf rb;
 	struct k_mutex tx_lock;
 	uint8_t tx_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];


### PR DESCRIPTION
W91 OT CLI works unstable with a 64 byte RX ISR buffer. This may be related to some issue with RTS and CTS signals and should be additionally verified. As a temporary solution, the ISR and general OT RCP buffer are set to the same size (256 bytes). TELINK_OT_RCP_RX_ISR_BUFFER_SIZE is removed because it is not currently used.