### PR TITLE
soc: telink: rcp: add intermediate transport layer

### DIFF
--- a/soc/telink/tlsr/common/CMakeLists.txt
+++ b/soc/telink/tlsr/common/CMakeLists.txt
@@ -13,10 +13,16 @@ zephyr_sources(
 	ot_rcp/spinel.c
 )
 
-if(CONFIG_TELINK_OT_RCP_UART)
+if(CONFIG_TELINK_OT_RCP_TRANSPORT_UART)
 
 zephyr_sources(
 	ot_rcp/transport/rcp_transport_uart.c
+)
+
+elseif(CONFIG_TELINK_OT_RCP_TRANSPORT_DUMMY)
+
+zephyr_sources(
+	ot_rcp/transport/rcp_transport_dummy.c
 )
 
 endif()

--- a/soc/telink/tlsr/common/CMakeLists.txt
+++ b/soc/telink/tlsr/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Nordic Semiconductor
+# Copyright (c) 2025 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(.)
@@ -12,6 +12,14 @@ zephyr_sources(
 	ot_rcp/spinel_drv.c
 	ot_rcp/spinel.c
 )
+
+if(CONFIG_TELINK_OT_RCP_UART)
+
+zephyr_sources(
+	ot_rcp/transport/rcp_transport_uart.c
+)
+
+endif()
 
 endif()
 

--- a/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
+++ b/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
@@ -16,6 +16,10 @@ if TELINK_OT_RCP
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	default 2048
 
+config TELINK_OT_RCP_UART
+	bool "Set UART as a transport for OT RCP"
+	default y
+
 config TELINK_OT_RCP_SYNC_TIME_OFFSET_MS
 	int "Time to recalculate offset (ms)"
 	default 2000

--- a/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
+++ b/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
@@ -16,9 +16,14 @@ if TELINK_OT_RCP
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	default 2048
 
-config TELINK_OT_RCP_UART
-	bool "Set UART as a transport for OT RCP"
-	default y
+choice TELINK_OT_RCP_TRANSPORT
+	bool "Transport for the OT RCP"
+	default TELINK_OT_RCP_UART
+
+	config TELINK_OT_RCP_UART
+		bool "Set UART as a transport for the OT RCP"
+
+endchoice # TELINK_OT_RCP_TRANSPORT
 
 config TELINK_OT_RCP_SYNC_TIME_OFFSET_MS
 	int "Time to recalculate offset (ms)"

--- a/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
+++ b/soc/telink/tlsr/common/ot_rcp/Kconfig.ot_rcp
@@ -18,10 +18,13 @@ config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 
 choice TELINK_OT_RCP_TRANSPORT
 	bool "Transport for the OT RCP"
-	default TELINK_OT_RCP_UART
+	default TELINK_OT_RCP_TRANSPORT_UART
 
-	config TELINK_OT_RCP_UART
+	config TELINK_OT_RCP_TRANSPORT_UART
 		bool "Set UART as a transport for the OT RCP"
+
+	config TELINK_OT_RCP_TRANSPORT_DUMMY
+		bool "Set dummy as a transport for the OT RCP"
 
 endchoice # TELINK_OT_RCP_TRANSPORT
 

--- a/soc/telink/tlsr/common/ot_rcp/ot_rcp.c
+++ b/soc/telink/tlsr/common/ot_rcp/ot_rcp.c
@@ -15,9 +15,10 @@ LOG_MODULE_REGISTER(ot_rcp);
 #include <zephyr/drivers/timer/system_timer.h>
 
 /************************************************************************
- * RCP reception work queue
+ * RCP work queue
  ************************************************************************/
 
+#if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_TXTIME)
 static K_KERNEL_STACK_DEFINE(openthread_rcp_work_q_stack, CONFIG_TELINK_OT_RCP_THREAD_STACK_SIZE);
 
 static struct k_work_q openthread_rcp_work_q;
@@ -25,7 +26,7 @@ static struct k_work_q openthread_rcp_work_q;
 static int openthread_rcp_work_q_init(void)
 {
 	struct k_work_queue_config cfg = {
-		.name = "rcpworkq", .no_yield = false, .essential = false};
+		.name = "ot_rcp_workq", .no_yield = false, .essential = false};
 
 	k_work_queue_start(&openthread_rcp_work_q, openthread_rcp_work_q_stack,
 			   K_KERNEL_STACK_SIZEOF(openthread_rcp_work_q_stack),
@@ -34,39 +35,17 @@ static int openthread_rcp_work_q_init(void)
 }
 
 SYS_INIT(openthread_rcp_work_q_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+#endif /* CONFIG_NET_PKT_TIMESTAMP || CONFIG_NET_PKT_TXTIME */
 
 /************************************************************************
  * RCP internal functions
  ************************************************************************/
 
-static void openthread_rcp_reception_isr(const struct device *dev, void *user_data)
+static void openthread_rcp_reception_handler(const void *ctx, uint8_t bt)
 {
-	struct openthread_rcp_data *ot_rcp = (struct openthread_rcp_data *)user_data;
+	struct openthread_rcp_data *ot_rcp = (struct openthread_rcp_data *)ctx;
 
-	if (rcp_transport_receive(dev, &ot_rcp->rb) != 0) {
-		LOG_ERR("rcp_transport transmit error");
-		return;
-	}
-
-	if (!ring_buf_is_empty(&ot_rcp->rb)) {
-		k_work_submit_to_queue(&openthread_rcp_work_q, &ot_rcp->work);
-	}
-}
-
-static void openthread_rcp_reception_work(struct k_work *item)
-{
-	struct openthread_rcp_data *ot_rcp = CONTAINER_OF(item, struct openthread_rcp_data, work);
-
-	for (;;) {
-		uint8_t bt;
-
-		if (ring_buf_get(&ot_rcp->rb, &bt, sizeof(bt)) == sizeof(bt)) {
-			hdlc_coder_inp_poll(&ot_rcp->hdlc, bt);
-		} else {
-			break;
-		}
-	}
-	rcp_transport_irq_enable(ot_rcp->rcp_transport_dev);
+	hdlc_coder_inp_poll(&ot_rcp->hdlc, bt);
 }
 
 static void openthread_rcp_spinel_transmission(uint8_t bt, const void *ctx)
@@ -99,7 +78,7 @@ static int openthread_rcp_process_start(struct openthread_rcp_data *ot_rcp,
 	size_t tx_len = ot_rcp->tx_buffer.data_size;
 
 	while (tx_len) {
-		int r = rcp_transport_transmit(ot_rcp->rcp_transport_dev, tx_ptr, tx_len);
+		int r = rcp_transport_transmit(&ot_rcp->rcp_transport, tx_ptr, tx_len);
 
 		if (r < 0) {
 			result = r;
@@ -246,20 +225,11 @@ static void openthread_rcp_reception_done(bool data_valid, const void *ctx)
  * RCP interface functions
  ************************************************************************/
 
-int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const struct device *rcp_transport_dev)
+int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const void *transport_device)
 {
 	int result = 0;
 
 	do {
-		if (!device_is_ready(rcp_transport_dev)) {
-			LOG_ERR("spinel serial not ready");
-			result = -EIO;
-			break;
-		}
-
-		ot_rcp->rcp_transport_dev = rcp_transport_dev;
-		ring_buf_init(&ot_rcp->rb, sizeof(ot_rcp->rb_data), ot_rcp->rb_data);
-		k_work_init(&ot_rcp->work, openthread_rcp_reception_work);
 #if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_TXTIME)
 		k_work_init_delayable(&ot_rcp->sync_work, openthread_rcp_sync_time_work_handler);
 		k_mutex_init(&ot_rcp->time_lock);
@@ -278,14 +248,13 @@ int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const struct device 
 		spinel_drv_init(&ot_rcp->spinel_drv, 0);
 		ot_rcp->reception = NULL;
 		ot_rcp->ctx = NULL;
-
-		if (rcp_transport_set_callback(ot_rcp->rcp_transport_dev,
-					       openthread_rcp_reception_isr, ot_rcp)) {
-			LOG_ERR("can't set serial isr");
+		if (rcp_transport_init(&ot_rcp->rcp_transport, transport_device, ot_rcp)) {
 			result = -EIO;
 			break;
 		}
-		rcp_transport_irq_enable(ot_rcp->rcp_transport_dev);
+		rcp_transport_reception_handler_set(&ot_rcp->rcp_transport,
+						    openthread_rcp_reception_handler);
+		rcp_transport_irq_enable(&ot_rcp->rcp_transport);
 	} while (0);
 
 	return result;
@@ -303,18 +272,13 @@ int openthread_rcp_deinit(struct openthread_rcp_data *ot_rcp)
 	int result = 0;
 
 	do {
-		rcp_transport_irq_disable(ot_rcp->rcp_transport_dev);
-		if (rcp_transport_set_callback(ot_rcp->rcp_transport_dev, NULL, NULL)) {
+		rcp_transport_irq_disable(&ot_rcp->rcp_transport);
+		if (rcp_transport_deinit(&ot_rcp->rcp_transport)) {
 			LOG_ERR("can't reset serial isr");
 			result = -EIO;
 			break;
 		}
-
-		struct k_work_sync work_sync;
-
-		(void)k_work_cancel_sync(&ot_rcp->work, &work_sync);
 		k_msgq_purge(&ot_rcp->spinel_msgq);
-		ring_buf_reset(&ot_rcp->rb);
 	} while (0);
 
 	return result;

--- a/soc/telink/tlsr/common/ot_rcp/ot_rcp.c
+++ b/soc/telink/tlsr/common/ot_rcp/ot_rcp.c
@@ -12,7 +12,6 @@
 LOG_MODULE_REGISTER(ot_rcp);
 
 #include <zephyr/init.h>
-#include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/timer/system_timer.h>
 
 /************************************************************************
@@ -44,26 +43,11 @@ static void openthread_rcp_reception_isr(const struct device *dev, void *user_da
 {
 	struct openthread_rcp_data *ot_rcp = (struct openthread_rcp_data *)user_data;
 
-	if (!uart_irq_update(dev)) {
+	if (rcp_transport_receive(dev, &ot_rcp->rb) != 0) {
+		LOG_ERR("rcp_transport transmit error");
 		return;
 	}
-	while (uart_irq_rx_ready(dev)) {
-		uint8_t bt;
 
-		if (ring_buf_space_get(&ot_rcp->rb) > sizeof(bt)) {
-			int r = uart_fifo_read(dev, &bt, sizeof(bt));
-
-			if (r < 0) {
-				LOG_ERR("rcp uart reception error");
-			} else if (r > 0) {
-				(void)ring_buf_put(&ot_rcp->rb, &bt, r);
-			}
-		} else {
-			/* that's ok for hw flow control */
-			uart_irq_rx_disable(dev);
-			break;
-		}
-	}
 	if (!ring_buf_is_empty(&ot_rcp->rb)) {
 		k_work_submit_to_queue(&openthread_rcp_work_q, &ot_rcp->work);
 	}
@@ -82,7 +66,7 @@ static void openthread_rcp_reception_work(struct k_work *item)
 			break;
 		}
 	}
-	uart_irq_rx_enable(ot_rcp->uart);
+	rcp_transport_irq_enable(ot_rcp->rcp_transport_dev);
 }
 
 static void openthread_rcp_spinel_transmission(uint8_t bt, const void *ctx)
@@ -115,7 +99,7 @@ static int openthread_rcp_process_start(struct openthread_rcp_data *ot_rcp,
 	size_t tx_len = ot_rcp->tx_buffer.data_size;
 
 	while (tx_len) {
-		int r = uart_fifo_fill(ot_rcp->uart, tx_ptr, tx_len);
+		int r = rcp_transport_transmit(ot_rcp->rcp_transport_dev, tx_ptr, tx_len);
 
 		if (r < 0) {
 			result = r;
@@ -126,7 +110,7 @@ static int openthread_rcp_process_start(struct openthread_rcp_data *ot_rcp,
 		result += r;
 	}
 	if (result != ot_rcp->tx_buffer.data_size) {
-		LOG_ERR("rcp uart transmission error %u", result);
+		LOG_ERR("rcp rcp_transport transmission error %u", result);
 		result = result < 0 ? result : -EIO;
 	}
 	ot_rcp->tx_buffer.data_size = 0;
@@ -262,18 +246,18 @@ static void openthread_rcp_reception_done(bool data_valid, const void *ctx)
  * RCP interface functions
  ************************************************************************/
 
-int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const struct device *uart)
+int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const struct device *rcp_transport_dev)
 {
 	int result = 0;
 
 	do {
-		if (!device_is_ready(uart)) {
+		if (!device_is_ready(rcp_transport_dev)) {
 			LOG_ERR("spinel serial not ready");
 			result = -EIO;
 			break;
 		}
 
-		ot_rcp->uart = uart;
+		ot_rcp->rcp_transport_dev = rcp_transport_dev;
 		ring_buf_init(&ot_rcp->rb, sizeof(ot_rcp->rb_data), ot_rcp->rb_data);
 		k_work_init(&ot_rcp->work, openthread_rcp_reception_work);
 #if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_TXTIME)
@@ -295,13 +279,13 @@ int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const struct device 
 		ot_rcp->reception = NULL;
 		ot_rcp->ctx = NULL;
 
-		if (uart_irq_callback_user_data_set(ot_rcp->uart, openthread_rcp_reception_isr,
-						    ot_rcp)) {
+		if (rcp_transport_set_callback(ot_rcp->rcp_transport_dev,
+					       openthread_rcp_reception_isr, ot_rcp)) {
 			LOG_ERR("can't set serial isr");
 			result = -EIO;
 			break;
 		}
-		uart_irq_rx_enable(ot_rcp->uart);
+		rcp_transport_irq_enable(ot_rcp->rcp_transport_dev);
 	} while (0);
 
 	return result;
@@ -319,8 +303,8 @@ int openthread_rcp_deinit(struct openthread_rcp_data *ot_rcp)
 	int result = 0;
 
 	do {
-		uart_irq_rx_disable(ot_rcp->uart);
-		if (uart_irq_callback_user_data_set(ot_rcp->uart, NULL, NULL)) {
+		rcp_transport_irq_disable(ot_rcp->rcp_transport_dev);
+		if (rcp_transport_set_callback(ot_rcp->rcp_transport_dev, NULL, NULL)) {
 			LOG_ERR("can't reset serial isr");
 			result = -EIO;
 			break;

--- a/soc/telink/tlsr/common/ot_rcp/ot_rcp.c
+++ b/soc/telink/tlsr/common/ot_rcp/ot_rcp.c
@@ -59,13 +59,7 @@ static void openthread_rcp_hdlc_transmission(uint8_t bt, const void *ctx)
 {
 	struct openthread_rcp_data *ot_rcp = (struct openthread_rcp_data *)ctx;
 
-	if (ot_rcp->tx_buffer.data_size < sizeof(ot_rcp->tx_data)) {
-		ot_rcp->tx_buffer.data[ot_rcp->tx_buffer.data_size] = bt;
-		ot_rcp->tx_buffer.data_size++;
-	} else {
-		LOG_ERR("rcp tx buffer overflow");
-		ot_rcp->tx_buffer.data_size = 0;
-	}
+	rcp_transport_put_byte(&ot_rcp->rcp_transport, bt);
 }
 
 static int openthread_rcp_process_start(struct openthread_rcp_data *ot_rcp,
@@ -73,26 +67,8 @@ static int openthread_rcp_process_start(struct openthread_rcp_data *ot_rcp,
 {
 	hdlc_coder_out_finish(&ot_rcp->hdlc, true);
 
-	int result = 0;
-	const uint8_t *tx_ptr = ot_rcp->tx_buffer.data;
-	size_t tx_len = ot_rcp->tx_buffer.data_size;
+	int result = rcp_transport_transmit(&ot_rcp->rcp_transport);
 
-	while (tx_len) {
-		int r = rcp_transport_transmit(&ot_rcp->rcp_transport, tx_ptr, tx_len);
-
-		if (r < 0) {
-			result = r;
-			break;
-		}
-		tx_ptr += r;
-		tx_len -= r;
-		result += r;
-	}
-	if (result != ot_rcp->tx_buffer.data_size) {
-		LOG_ERR("rcp rcp_transport transmission error %u", result);
-		result = result < 0 ? result : -EIO;
-	}
-	ot_rcp->tx_buffer.data_size = 0;
 	if (result >= 0) {
 		*start_time =
 			sys_timepoint_calc(K_MSEC(CONFIG_TELINK_OT_SPINEL_RESPONSE_TIMEOUT_MS));
@@ -235,8 +211,6 @@ int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const void *transpor
 		k_mutex_init(&ot_rcp->time_lock);
 #endif /* CONFIG_NET_PKT_TIMESTAMP || CONFIG_NET_PKT_TXTIME */
 		k_mutex_init(&ot_rcp->tx_lock);
-		ot_rcp->tx_buffer.data = ot_rcp->tx_data;
-		ot_rcp->tx_buffer.data_size = 0;
 		hdlc_coder_init(&ot_rcp->hdlc, ot_rcp);
 		hdlc_coder_out_data_set(&ot_rcp->hdlc, openthread_rcp_hdlc_transmission);
 		hdlc_coder_inp_data_set(&ot_rcp->hdlc, openthread_rcp_reception_byte);
@@ -254,7 +228,6 @@ int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const void *transpor
 		}
 		rcp_transport_reception_handler_set(&ot_rcp->rcp_transport,
 						    openthread_rcp_reception_handler);
-		rcp_transport_irq_enable(&ot_rcp->rcp_transport);
 	} while (0);
 
 	return result;
@@ -272,7 +245,6 @@ int openthread_rcp_deinit(struct openthread_rcp_data *ot_rcp)
 	int result = 0;
 
 	do {
-		rcp_transport_irq_disable(&ot_rcp->rcp_transport);
 		if (rcp_transport_deinit(&ot_rcp->rcp_transport)) {
 			LOG_ERR("can't reset serial isr");
 			result = -EIO;

--- a/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
+++ b/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
@@ -26,8 +26,6 @@ struct openthread_rcp_buffer {
 struct openthread_rcp_data {
 	struct rcp_transport_data rcp_transport;
 	struct k_mutex tx_lock;
-	uint8_t tx_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
-	struct openthread_rcp_buffer tx_buffer;
 	struct hdlc_coder hdlc;
 	struct openthread_rcp_buffer spinel_rx_buffer;
 	struct openthread_rcp_buffer spinel_msgq_buffer[CONFIG_TELINK_OT_SPINEL_RX_BUFFER_COUNT];

--- a/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
+++ b/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
@@ -14,6 +14,7 @@
 
 #include "hdlc_coder.h"
 #include "spinel_drv.h"
+#include "transport/rcp_transport.h"
 
 typedef void (*openthread_rcp_reception)(const struct spinel_frame_data *frame, const void *ctx);
 
@@ -23,7 +24,7 @@ struct openthread_rcp_buffer {
 };
 
 struct openthread_rcp_data {
-	const struct device *uart;
+	const struct device *rcp_transport_dev;
 	struct k_work work;
 	uint8_t rb_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
 	struct ring_buf rb;

--- a/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
+++ b/soc/telink/tlsr/common/ot_rcp/ot_rcp.h
@@ -24,10 +24,7 @@ struct openthread_rcp_buffer {
 };
 
 struct openthread_rcp_data {
-	const struct device *rcp_transport_dev;
-	struct k_work work;
-	uint8_t rb_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
-	struct ring_buf rb;
+	struct rcp_transport_data rcp_transport;
 	struct k_mutex tx_lock;
 	uint8_t tx_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
 	struct openthread_rcp_buffer tx_buffer;
@@ -47,7 +44,7 @@ struct openthread_rcp_data {
 #endif /* CONFIG_NET_PKT_TIMESTAMP || CONFIG_NET_PKT_TXTIME */
 };
 
-int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const struct device *uart);
+int openthread_rcp_init(struct openthread_rcp_data *ot_rcp, const void *transport_device);
 void openthread_rcp_reception_set(struct openthread_rcp_data *ot_rcp,
 				  openthread_rcp_reception reception, const void *ctx);
 int openthread_rcp_deinit(struct openthread_rcp_data *ot_rcp);

--- a/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport.h
+++ b/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport.h
@@ -13,15 +13,31 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 
-typedef void (*rcp_transport_irq_t)(const struct device *transport_dev, void *user_data);
+typedef void (*rpc_transport_reception_t)(const void *, uint8_t);
 
-int rcp_transport_receive(const struct device *rcp_transport_dev, struct ring_buf *dest_buffer);
-int rcp_transport_transmit(const struct device *rcp_transport_dev, const uint8_t *data,
+struct rcp_transport_data {
+	const void *device;
+	rpc_transport_reception_t reception_handler;
+	const void *ctx;
+	struct rcp_transport_uart_data {
+		struct k_work work;
+		struct ring_buf rb;
+		uint8_t rb_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
+	} data;
+};
+
+typedef void (*rcp_transport_irq_t)(struct rcp_transport_data rcp_transport);
+
+int rcp_transport_init(struct rcp_transport_data *rcp_transport, const void *transport_device,
+		       const void *ctx);
+int rcp_transport_deinit(struct rcp_transport_data *rcp_transport);
+
+int rcp_transport_transmit(const struct rcp_transport_data *rcp_transport, const uint8_t *data,
 			   size_t length);
+void rcp_transport_reception_handler_set(struct rcp_transport_data *rcp_transport,
+					 rpc_transport_reception_t rcp_transport_reception_handler);
 
-int rcp_transport_set_callback(const struct device *rcp_transport_dev, rcp_transport_irq_t cb,
-			       void *user_data);
-void rcp_transport_irq_enable(const struct device *rcp_transport_dev);
-void rcp_transport_irq_disable(const struct device *rcp_transport_dev);
+void rcp_transport_irq_enable(const struct rcp_transport_data *rcp_transport);
+void rcp_transport_irq_disable(const struct rcp_transport_data *rcp_transport);
 
 #endif

--- a/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport.h
+++ b/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RCP_TRANSPORT_H_
+#define RCP_TRANSPORT_H_
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+typedef void (*rcp_transport_irq_t)(const struct device *transport_dev, void *user_data);
+
+int rcp_transport_receive(const struct device *rcp_transport_dev, struct ring_buf *dest_buffer);
+int rcp_transport_transmit(const struct device *rcp_transport_dev, const uint8_t *data,
+			   size_t length);
+
+int rcp_transport_set_callback(const struct device *rcp_transport_dev, rcp_transport_irq_t cb,
+			       void *user_data);
+void rcp_transport_irq_enable(const struct device *rcp_transport_dev);
+void rcp_transport_irq_disable(const struct device *rcp_transport_dev);
+
+#endif

--- a/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport.h
+++ b/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport.h
@@ -14,16 +14,22 @@
 #include <zephyr/device.h>
 
 typedef void (*rpc_transport_reception_t)(const void *, uint8_t);
-
 struct rcp_transport_data {
 	const void *device;
+	uint8_t tx_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
+	size_t tx_data_size;
 	rpc_transport_reception_t reception_handler;
 	const void *ctx;
+#if defined(CONFIG_TELINK_OT_RCP_TRANSPORT_UART)
 	struct rcp_transport_uart_data {
 		struct k_work work;
 		struct ring_buf rb;
 		uint8_t rb_data[CONFIG_TELINK_OT_RCP_BUFFER_SIZE];
 	} data;
+#elif defined(CONFIG_TELINK_OT_RCP_TRANSPORT_DUMMY)
+	struct rcp_transport_dummy_data {
+	} data;
+#endif
 };
 
 typedef void (*rcp_transport_irq_t)(struct rcp_transport_data rcp_transport);
@@ -32,12 +38,8 @@ int rcp_transport_init(struct rcp_transport_data *rcp_transport, const void *tra
 		       const void *ctx);
 int rcp_transport_deinit(struct rcp_transport_data *rcp_transport);
 
-int rcp_transport_transmit(const struct rcp_transport_data *rcp_transport, const uint8_t *data,
-			   size_t length);
+int rcp_transport_transmit(struct rcp_transport_data *rcp_transport);
+void rcp_transport_put_byte(struct rcp_transport_data *rcp_transport, uint8_t bt);
 void rcp_transport_reception_handler_set(struct rcp_transport_data *rcp_transport,
 					 rpc_transport_reception_t rcp_transport_reception_handler);
-
-void rcp_transport_irq_enable(const struct rcp_transport_data *rcp_transport);
-void rcp_transport_irq_disable(const struct rcp_transport_data *rcp_transport);
-
 #endif

--- a/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_dummy.c
+++ b/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_dummy.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rcp_transport.h"
+
+#define LOG_LEVEL CONFIG_IEEE802154_DRIVER_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(rcp_transport_dummy);
+
+void rcp_transport_put_byte(struct rcp_transport_data *rcp_transport, uint8_t bt)
+{
+	if (rcp_transport->tx_data_size < sizeof(rcp_transport->tx_data)) {
+		rcp_transport->tx_data[rcp_transport->tx_data_size] = bt;
+		rcp_transport->tx_data_size++;
+	} else {
+		LOG_ERR("rcp tx buffer overflow");
+		rcp_transport->tx_data_size = 0;
+	}
+}
+
+int rcp_transport_transmit(struct rcp_transport_data *rcp_transport)
+{
+	return 0;
+}
+
+void rcp_transport_reception_handler_set(struct rcp_transport_data *rcp_transport,
+					 rpc_transport_reception_t rcp_transport_reception_handler)
+{
+	rcp_transport->reception_handler = rcp_transport_reception_handler;
+}
+
+int rcp_transport_init(struct rcp_transport_data *rcp_transport, const void *transport_device,
+		       const void *ctx)
+{
+	rcp_transport->device = transport_device;
+	rcp_transport->ctx = ctx;
+	return 0;
+}
+
+int rcp_transport_deinit(struct rcp_transport_data *rcp_transport)
+{
+	return 0;
+}

--- a/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_uart.c
+++ b/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_uart.c
@@ -55,7 +55,7 @@ static void rcp_transport_reception_work(struct k_work *item)
 			break;
 		}
 	}
-	rcp_transport_irq_enable(rcp_transport);
+	uart_irq_rx_enable((const struct device *)rcp_transport->device);
 }
 
 static void rcp_transport_reception_isr(const struct device *dev, void *user_data)
@@ -91,26 +91,49 @@ static void rcp_transport_reception_isr(const struct device *dev, void *user_dat
  * RCP transport interface functions
  ************************************************************************/
 
-int rcp_transport_transmit(const struct rcp_transport_data *rcp_transport, const uint8_t *data,
-			   size_t length)
+void rcp_transport_put_byte(struct rcp_transport_data *rcp_transport, uint8_t bt)
 {
-	return uart_fifo_fill((const struct device *)rcp_transport->device, data, length);
+	if (rcp_transport->tx_data_size < sizeof(rcp_transport->tx_data)) {
+		rcp_transport->tx_data[rcp_transport->tx_data_size] = bt;
+		rcp_transport->tx_data_size++;
+	} else {
+		LOG_ERR("rcp tx buffer overflow");
+		rcp_transport->tx_data_size = 0;
+	}
+}
+
+int rcp_transport_transmit(struct rcp_transport_data *rcp_transport)
+{
+	int result = 0;
+	const uint8_t *tx_ptr = rcp_transport->tx_data;
+	size_t tx_len = rcp_transport->tx_data_size;
+
+	while (tx_len) {
+		int r = uart_fifo_fill((const struct device *)rcp_transport->device, tx_ptr,
+				       tx_len);
+
+		if (r < 0) {
+			result = r;
+			break;
+		}
+		tx_ptr += r;
+		tx_len -= r;
+		result += r;
+	}
+	if (result != rcp_transport->tx_data_size) {
+		LOG_ERR("rcp rcp_transport transmission error %u", result);
+		result = result < 0 ? result : -EIO;
+	}
+	rcp_transport->tx_data_size = 0;
+
+	return result;
 }
 
 void rcp_transport_reception_handler_set(struct rcp_transport_data *rcp_transport,
 					 rpc_transport_reception_t rcp_transport_reception_handler)
 {
 	rcp_transport->reception_handler = rcp_transport_reception_handler;
-}
-
-void rcp_transport_irq_enable(const struct rcp_transport_data *rcp_transport)
-{
 	uart_irq_rx_enable((const struct device *)rcp_transport->device);
-}
-
-void rcp_transport_irq_disable(const struct rcp_transport_data *rcp_transport)
-{
-	uart_irq_rx_disable((const struct device *)rcp_transport->device);
 }
 
 int rcp_transport_init(struct rcp_transport_data *rcp_transport, const void *transport_device,
@@ -124,6 +147,7 @@ int rcp_transport_init(struct rcp_transport_data *rcp_transport, const void *tra
 	rcp_transport->ctx = ctx;
 
 	do {
+		rcp_transport->tx_data_size = 0;
 		ring_buf_init(&rcp_transport->data.rb, sizeof(rcp_transport->data.rb_data),
 			      rcp_transport->data.rb_data);
 		k_work_init(&rcp_transport->data.work, rcp_transport_reception_work);
@@ -142,6 +166,8 @@ int rcp_transport_init(struct rcp_transport_data *rcp_transport, const void *tra
 int rcp_transport_deinit(struct rcp_transport_data *rcp_transport)
 {
 	int result = 0;
+
+	uart_irq_rx_disable((const struct device *)rcp_transport->device);
 
 	do {
 		if (uart_irq_callback_user_data_set((const struct device *)rcp_transport->device,

--- a/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_uart.c
+++ b/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_uart.c
@@ -13,45 +13,148 @@ LOG_MODULE_REGISTER(rcp_transport_uart);
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/ring_buffer.h>
 
-int rcp_transport_set_callback(const struct device *rcp_transport_dev, rcp_transport_irq_t cb,
-			       void *user_data)
+/************************************************************************
+ * RCP transport reception work queue
+ ************************************************************************/
+
+static K_KERNEL_STACK_DEFINE(rcp_transport_uart_work_q_stack,
+			     CONFIG_TELINK_OT_RCP_THREAD_STACK_SIZE);
+
+static struct k_work_q rcp_transport_uart_work_q;
+
+static int rcp_transport_uart_work_q_init(void)
 {
-	return uart_irq_callback_user_data_set(rcp_transport_dev, cb, user_data);
+	struct k_work_queue_config cfg = {
+		.name = "rcp_transport_uart_workq", .no_yield = false, .essential = false};
+
+	k_work_queue_start(&rcp_transport_uart_work_q, rcp_transport_uart_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(rcp_transport_uart_work_q_stack),
+			   CONFIG_TELINK_OT_RCP_THREAD_PRIORITY, &cfg);
+	return 0;
 }
 
-void rcp_transport_irq_enable(const struct device *rcp_transport_dev)
-{
-	uart_irq_rx_enable(rcp_transport_dev);
-}
+SYS_INIT(rcp_transport_uart_work_q_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
-int rcp_transport_transmit(const struct device *rcp_transport_dev, const uint8_t *data,
-			   size_t length)
-{
-	return uart_fifo_fill(rcp_transport_dev, data, length);
-}
+/************************************************************************
+ * RCP transport internal functions
+ ************************************************************************/
 
-int rcp_transport_receive(const struct device *rcp_transport_dev, struct ring_buf *dest_buffer)
+static void rcp_transport_reception_work(struct k_work *item)
 {
-	if (!uart_irq_update(rcp_transport_dev)) {
-		return -ENOTSUP;
-	}
-	while (uart_irq_rx_ready(rcp_transport_dev)) {
+	struct rcp_transport_uart_data *rcp_transport_uart =
+		CONTAINER_OF(item, struct rcp_transport_uart_data, work);
+	struct rcp_transport_data *rcp_transport =
+		CONTAINER_OF(rcp_transport_uart, struct rcp_transport_data, data);
+
+	for (;;) {
 		uint8_t bt;
 
-		if (ring_buf_space_get(dest_buffer) > sizeof(bt)) {
-			int r = uart_fifo_read(rcp_transport_dev, &bt, sizeof(bt));
+		if (ring_buf_get(&rcp_transport->data.rb, &bt, sizeof(bt)) == sizeof(bt)) {
+			rcp_transport->reception_handler(rcp_transport->ctx, bt);
+		} else {
+			break;
+		}
+	}
+	rcp_transport_irq_enable(rcp_transport);
+}
+
+static void rcp_transport_reception_isr(const struct device *dev, void *user_data)
+{
+	struct rcp_transport_data *rcp_transport = (struct rcp_transport_data *)user_data;
+
+	if (!uart_irq_update(dev)) {
+		return;
+	}
+	while (uart_irq_rx_ready(dev)) {
+		uint8_t bt;
+
+		if (ring_buf_space_get(&rcp_transport->data.rb) > sizeof(bt)) {
+			int r = uart_fifo_read(dev, &bt, sizeof(bt));
 
 			if (r < 0) {
 				LOG_ERR("rcp uart reception error");
 			} else if (r > 0) {
-				(void)ring_buf_put(dest_buffer, &bt, r);
+				(void)ring_buf_put(&rcp_transport->data.rb, &bt, r);
 			}
 		} else {
 			/* that's ok for hw flow control */
-			uart_irq_rx_disable(rcp_transport_dev);
-			return 0;
+			uart_irq_rx_disable(dev);
+			break;
 		}
 	}
+	if (!ring_buf_is_empty(&rcp_transport->data.rb)) {
+		k_work_submit_to_queue(&rcp_transport_uart_work_q, &rcp_transport->data.work);
+	}
+}
 
-	return 0;
+/************************************************************************
+ * RCP transport interface functions
+ ************************************************************************/
+
+int rcp_transport_transmit(const struct rcp_transport_data *rcp_transport, const uint8_t *data,
+			   size_t length)
+{
+	return uart_fifo_fill((const struct device *)rcp_transport->device, data, length);
+}
+
+void rcp_transport_reception_handler_set(struct rcp_transport_data *rcp_transport,
+					 rpc_transport_reception_t rcp_transport_reception_handler)
+{
+	rcp_transport->reception_handler = rcp_transport_reception_handler;
+}
+
+void rcp_transport_irq_enable(const struct rcp_transport_data *rcp_transport)
+{
+	uart_irq_rx_enable((const struct device *)rcp_transport->device);
+}
+
+void rcp_transport_irq_disable(const struct rcp_transport_data *rcp_transport)
+{
+	uart_irq_rx_disable((const struct device *)rcp_transport->device);
+}
+
+int rcp_transport_init(struct rcp_transport_data *rcp_transport, const void *transport_device,
+		       const void *ctx)
+{
+	LOG_DBG("%s", __func__);
+
+	int result = 0;
+
+	rcp_transport->device = transport_device;
+	rcp_transport->ctx = ctx;
+
+	do {
+		ring_buf_init(&rcp_transport->data.rb, sizeof(rcp_transport->data.rb_data),
+			      rcp_transport->data.rb_data);
+		k_work_init(&rcp_transport->data.work, rcp_transport_reception_work);
+		if (uart_irq_callback_user_data_set((const struct device *)rcp_transport->device,
+						    rcp_transport_reception_isr,
+						    (void *)rcp_transport)) {
+			result = -EIO;
+			LOG_ERR("spinel uart interrupt setting failed");
+			break;
+		}
+	} while (0);
+
+	return result;
+}
+
+int rcp_transport_deinit(struct rcp_transport_data *rcp_transport)
+{
+	int result = 0;
+
+	do {
+		if (uart_irq_callback_user_data_set((const struct device *)rcp_transport->device,
+						    NULL, NULL)) {
+			result = -EIO;
+			break;
+		}
+
+		struct k_work_sync work_sync;
+		(void)k_work_cancel_sync(&rcp_transport->data.work, &work_sync);
+
+		ring_buf_reset(&rcp_transport->data.rb);
+	} while (0);
+
+	return result;
 }

--- a/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_uart.c
+++ b/soc/telink/tlsr/common/ot_rcp/transport/rcp_transport_uart.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rcp_transport.h"
+
+#define LOG_LEVEL CONFIG_IEEE802154_DRIVER_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(rcp_transport_uart);
+
+#include <zephyr/drivers/uart.h>
+#include <zephyr/sys/ring_buffer.h>
+
+int rcp_transport_set_callback(const struct device *rcp_transport_dev, rcp_transport_irq_t cb,
+			       void *user_data)
+{
+	return uart_irq_callback_user_data_set(rcp_transport_dev, cb, user_data);
+}
+
+void rcp_transport_irq_enable(const struct device *rcp_transport_dev)
+{
+	uart_irq_rx_enable(rcp_transport_dev);
+}
+
+int rcp_transport_transmit(const struct device *rcp_transport_dev, const uint8_t *data,
+			   size_t length)
+{
+	return uart_fifo_fill(rcp_transport_dev, data, length);
+}
+
+int rcp_transport_receive(const struct device *rcp_transport_dev, struct ring_buf *dest_buffer)
+{
+	if (!uart_irq_update(rcp_transport_dev)) {
+		return -ENOTSUP;
+	}
+	while (uart_irq_rx_ready(rcp_transport_dev)) {
+		uint8_t bt;
+
+		if (ring_buf_space_get(dest_buffer) > sizeof(bt)) {
+			int r = uart_fifo_read(rcp_transport_dev, &bt, sizeof(bt));
+
+			if (r < 0) {
+				LOG_ERR("rcp uart reception error");
+			} else if (r > 0) {
+				(void)ring_buf_put(dest_buffer, &bt, r);
+			}
+		} else {
+			/* that's ok for hw flow control */
+			uart_irq_rx_disable(rcp_transport_dev);
+			return 0;
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add wrapper layer for the RCP communication
protocol to provide multiple options instead of
hardcoded UART.