### PR TITLE
soc: riscv: telink_tlx: Add nested interrupts

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -602,7 +602,7 @@ static int plic_init(const struct device *dev)
 	}
 
 	/* Set priority of each interrupt line to 0 initially */
-	for (uint32_t i = 0; i < config->nr_irqs; i++) {
+	for (uint32_t i = 1; i <= config->nr_irqs; i++) {
 		sys_write32(0U, prio_addr + (i * sizeof(uint32_t)));
 	}
 

--- a/samples/boards/tlsr9x/nested_isr/CMakeLists.txt
+++ b/samples/boards/tlsr9x/nested_isr/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(nested_isr)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/boards/tlsr9x/nested_isr/prj.conf
+++ b/samples/boards/tlsr9x/nested_isr/prj.conf
@@ -1,0 +1,1 @@
+# Empty file

--- a/samples/boards/tlsr9x/nested_isr/src/main.c
+++ b/samples/boards/tlsr9x/nested_isr/src/main.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/interrupt_controller/riscv_plic.h>
+#include <timer.h>
+
+/***************************************
+ * Timer 0 - high priority ISR
+ * Timer 1 - low priority ISR
+ ***************************************/
+
+#define TIMER_CAPTURE_TICKS 40000000
+#define TIMER0_ISR_NUMBER   4
+#define TIMER1_ISR_NUMBER   3
+
+static size_t counter;
+
+static void high_prio_timer_start(void)
+{
+	timer_set_init_tick(TIMER0, 0);
+	timer_start(TIMER0);
+}
+
+static void high_prio_timer_stop(void)
+{
+	timer_stop(TIMER0);
+}
+
+static void high_prio_timer_isr(volatile size_t *cnt)
+{
+	timer_clr_irq_status(FLD_TMR0_MODE_IRQ);
+	printk("Timer 0 ISR - High priority, counter = %zu\n", *cnt);
+	*cnt += 1;
+}
+
+static void low_prio_timer_isr(volatile size_t *cnt)
+{
+	timer_clr_irq_status(FLD_TMR1_MODE_IRQ);
+	printk("Timer 1 ISR - Low priority start\n");
+	*cnt = 0;
+	high_prio_timer_start();
+	for (; *cnt < 3;) {
+	}
+	high_prio_timer_stop();
+	printk("Timer 1 ISR - Low priority finish\n");
+}
+
+static void high_prio_timer_init(void)
+{
+	timer_set_cap_tick(TIMER0, TIMER_CAPTURE_TICKS / 10);
+	timer_set_mode(TIMER0, TIMER_MODE_SYSCLK);
+	timer_set_irq_mask(FLD_TMR0_MODE_IRQ);
+	IRQ_CONNECT(CONFIG_2ND_LVL_ISR_TBL_OFFSET + TIMER0_ISR_NUMBER, 2, high_prio_timer_isr,
+		    &counter, 0);
+	riscv_plic_set_priority(IRQ_TO_L2(TIMER0_ISR_NUMBER), 2);
+	riscv_plic_irq_enable(IRQ_TO_L2(TIMER0_ISR_NUMBER));
+}
+
+static void low_prio_timer_init(void)
+{
+	timer_set_cap_tick(TIMER1, TIMER_CAPTURE_TICKS);
+	timer_set_mode(TIMER1, TIMER_MODE_SYSCLK);
+	timer_set_irq_mask(FLD_TMR1_MODE_IRQ);
+	IRQ_CONNECT(CONFIG_2ND_LVL_ISR_TBL_OFFSET + TIMER1_ISR_NUMBER, 1, low_prio_timer_isr,
+		    &counter, 0);
+	riscv_plic_set_priority(IRQ_TO_L2(TIMER1_ISR_NUMBER), 1);
+	riscv_plic_irq_enable(IRQ_TO_L2(TIMER1_ISR_NUMBER));
+	/* start it now */
+	timer_set_init_tick(TIMER1, 0);
+	timer_start(TIMER1);
+}
+
+static void show_isr_configuration(void)
+{
+	uint32_t mmisc_ctl = csr_read(0x7d0);
+
+	printk("mmisc_ctl %08x [vector mode %s]\n", mmisc_ctl,
+	       mmisc_ctl & 0x2 ? "enabled" : "disabled");
+
+	const uint32_t *const plic_base = (uint32_t *)DT_REG_ADDR(DT_NODELABEL(plic0));
+	const size_t plic_isr_num = DT_PROP(DT_NODELABEL(plic0), riscv_ndev);
+
+	printk("PLIC base address %p\n", plic_base);
+	printk("PLIC_FEN %08x [vector mode %s, preemptive priority interrupt %s]\n", *plic_base,
+	       *plic_base & 0x2 ? "enabled" : "disabled",
+	       *plic_base & 0x1 ? "enabled" : "disabled");
+	printk("PLIC_PRI:\n");
+	for (size_t i = 1; i <= plic_isr_num; i++) {
+		if (*(plic_base + i)) {
+			printk("[%02zu] %u\n", i, *(plic_base + i));
+		}
+	}
+	printk("PLIC_IE:");
+	for (size_t i = 1; i <= plic_isr_num; i++) {
+		size_t word = i / 32;
+		uint8_t bit = i % 32;
+
+		if (*((uint32_t *)((uint8_t *)plic_base + 0x2000) + word) & (1 << bit)) {
+			printk(" %02zu", i);
+		}
+	}
+	printk("\n");
+}
+
+int main(void)
+{
+	printk("app started\n");
+	high_prio_timer_init();
+	low_prio_timer_init();
+	show_isr_configuration();
+	return 0;
+}

--- a/soc/telink/tlsr/telink_tlx/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_tlx/CMakeLists.txt
@@ -23,6 +23,11 @@ zephyr_sources_ifdef(CONFIG_PM
 	power.c
 )
 
+zephyr_sources_ifdef(CONFIG_RISCV_VECTORED_MODE
+	isr_table.c
+	isr_vectored.S
+)
+
 zephyr_sources_ifdef(CONFIG_MCUBOOT_ACTION_HOOKS
 	mcuboot_status_change.c
 )
@@ -31,6 +36,11 @@ zephyr_sources_ifdef(CONFIG_MCUBOOT_ACTION_HOOKS
 zephyr_ld_options(-fuse-ld=bfd)
 
 # Set compile options
+zephyr_linker_sources_ifdef(CONFIG_RISCV_VECTORED_MODE
+	ROM_START
+	SORT_KEY 0x0vectors
+	${ZEPHYR_BASE}/include/zephyr/linker/irq-vector-table-section.ld
+)
 zephyr_compile_options_ifdef(CONFIG_ANDES_HWDSP -mext-dsp)
 zephyr_compile_options_ifndef(CONFIG_RISCV_GP -mno-relax)
 zephyr_linker_sources(ROM_START SORT_KEY 0x0 init.ld)

--- a/soc/telink/tlsr/telink_tlx/Kconfig.defconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig.defconfig
@@ -9,6 +9,9 @@ config SYS_CLOCK_EXISTS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32000
 
+config RISCV_VECTORED_MODE
+	default y
+
 config RISCV_SOC_INTERRUPT_INIT
 	default y
 

--- a/soc/telink/tlsr/telink_tlx/isr_table.c
+++ b/soc/telink/tlsr/telink_tlx/isr_table.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sw_isr_table.h>
+#include <zephyr/kernel.h>
+
+#define _IRQ_VECTOR_NUMBER             UTIL_OR(DT_PROP(DT_NODELABEL(plic0), riscv_ndev), 0)
+#define _IRQ_VECTOR_PLIC_COMP_ADDR     (DT_REG_ADDR(DT_NODELABEL(plic0)) + 0x200004)
+#define _IRQ_VECTOR_TABLE_RECORD(i, _) ((uintptr_t)&_isr_vectored_wrapper)
+
+extern void _isr_vectored_wrapper(void);
+
+uintptr_t __irq_vector_table _irq_vector_table[_IRQ_VECTOR_NUMBER + 1] = {
+	((uintptr_t)&_isr_wrapper), LISTIFY(_IRQ_VECTOR_NUMBER, _IRQ_VECTOR_TABLE_RECORD, (,)) };
+
+void _irq_vector_handler(uint32_t num)
+{
+	struct _isr_table_entry *entry = &_sw_isr_table[CONFIG_2ND_LVL_ISR_TBL_OFFSET + num];
+
+	csr_set(mstatus, MSTATUS_IEN);
+	entry->isr(entry->arg);
+	csr_clear(mstatus, MSTATUS_IEN);
+	*(volatile uint32_t *)(_IRQ_VECTOR_PLIC_COMP_ADDR) = num;
+}

--- a/soc/telink/tlsr/telink_tlx/isr_vectored.S
+++ b/soc/telink/tlsr/telink_tlx/isr_vectored.S
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) 2016 Jean-Paul Etienne <fractalclone@gmail.com>
+ * Copyright (c) 2018 Foundries.io Ltd
+ * Copyright (c) 2020 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <offsets_short.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/syscall.h>
+#include <zephyr/arch/riscv/csr.h>
+#include <zephyr/arch/riscv/irq.h>
+#include <zephyr/arch/riscv/syscall.h>
+#include <../arch/riscv/core/asm_macros.inc>
+
+#ifdef CONFIG_RISCV_SOC_HAS_ISR_STACKING
+#include <soc_isr_stacking.h>
+#endif
+
+#define _IRQ_VECTOR_PLIC_COMP_ADDR                     (DT_REG_ADDR(DT_NODELABEL(plic0)) + 0x200004)
+
+/* Convenience macro for loading/storing register states. */
+#define DO_CALLER_SAVED(op) \
+	RV_E(	op t0, __struct_arch_esf_t0_OFFSET(sp)	);\
+	RV_E(	op t1, __struct_arch_esf_t1_OFFSET(sp)	);\
+	RV_E(	op t2, __struct_arch_esf_t2_OFFSET(sp)	);\
+	RV_I(	op t3, __struct_arch_esf_t3_OFFSET(sp)	);\
+	RV_I(	op t4, __struct_arch_esf_t4_OFFSET(sp)	);\
+	RV_I(	op t5, __struct_arch_esf_t5_OFFSET(sp)	);\
+	RV_I(	op t6, __struct_arch_esf_t6_OFFSET(sp)	);\
+	RV_E(	op a0, __struct_arch_esf_a0_OFFSET(sp)	);\
+	RV_E(	op a1, __struct_arch_esf_a1_OFFSET(sp)	);\
+	RV_E(	op a2, __struct_arch_esf_a2_OFFSET(sp)	);\
+	RV_E(	op a3, __struct_arch_esf_a3_OFFSET(sp)	);\
+	RV_E(	op a4, __struct_arch_esf_a4_OFFSET(sp)	);\
+	RV_E(	op a5, __struct_arch_esf_a5_OFFSET(sp)	);\
+	RV_I(	op a6, __struct_arch_esf_a6_OFFSET(sp)	);\
+	RV_I(	op a7, __struct_arch_esf_a7_OFFSET(sp)	);\
+	RV_E(	op ra, __struct_arch_esf_ra_OFFSET(sp)	)
+
+#ifdef CONFIG_EXCEPTION_DEBUG
+/* Convenience macro for storing callee saved register [s0 - s11] states. */
+#define STORE_CALLEE_SAVED() \
+	RV_E(	sr s0, ___callee_saved_t_s0_OFFSET(sp)		);\
+	RV_E(	sr s1, ___callee_saved_t_s1_OFFSET(sp)		);\
+	RV_I(	sr s2, ___callee_saved_t_s2_OFFSET(sp)		);\
+	RV_I(	sr s3, ___callee_saved_t_s3_OFFSET(sp)		);\
+	RV_I(	sr s4, ___callee_saved_t_s4_OFFSET(sp)		);\
+	RV_I(	sr s5, ___callee_saved_t_s5_OFFSET(sp)		);\
+	RV_I(	sr s6, ___callee_saved_t_s6_OFFSET(sp)		);\
+	RV_I(	sr s7, ___callee_saved_t_s7_OFFSET(sp)		);\
+	RV_I(	sr s8, ___callee_saved_t_s8_OFFSET(sp)		);\
+	RV_I(	sr s9, ___callee_saved_t_s9_OFFSET(sp)		);\
+	RV_I(	sr s10, ___callee_saved_t_s10_OFFSET(sp)	);\
+	RV_I(	sr s11, ___callee_saved_t_s11_OFFSET(sp)	)
+#endif /* CONFIG_EXCEPTION_DEBUG */
+
+	.macro get_current_cpu dst
+#if defined(CONFIG_SMP) || defined(CONFIG_USERSPACE)
+	csrr \dst, mscratch
+#else
+	la \dst, _kernel + ___kernel_t_cpus_OFFSET
+#endif
+	.endm
+
+/* imports */
+GTEXT(_irq_vector_handler)
+#ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
+GTEXT(__soc_save_context)
+GTEXT(__soc_restore_context)
+#endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */
+
+GTEXT(z_get_next_switch_handle)
+GTEXT(z_riscv_switch)
+
+#ifdef CONFIG_TRACING
+GTEXT(sys_trace_isr_enter)
+GTEXT(sys_trace_isr_exit)
+#endif
+
+#ifdef CONFIG_RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING
+GTEXT(__soc_handle_all_irqs)
+#endif
+
+/* exports */
+GTEXT(_isr_vectored_wrapper)
+
+/*
+ * Handler called upon each interrupt
+ */
+SECTION_FUNC(exception.entry, _isr_vectored_wrapper)
+
+/* Provide requested alignment, which depends e.g. on MTVEC format */
+.balign CONFIG_RISCV_TRAP_HANDLER_ALIGNMENT
+
+#ifdef CONFIG_USERSPACE
+	/* retrieve address of _current_cpu preserving s0 */
+	csrrw s0, mscratch, s0
+
+	/* preserve t0 and t1 temporarily */
+	sr t0, _curr_cpu_arch_user_exc_tmp0(s0)
+	sr t1, _curr_cpu_arch_user_exc_tmp1(s0)
+
+	/* determine if we come from user space */
+	csrr t0, mstatus
+	li t1, MSTATUS_MPP
+	and t0, t0, t1
+	bnez t0, 1f
+
+	/* in user space we were: switch to our privileged stack */
+	mv t0, sp
+	lr sp, _curr_cpu_arch_user_exc_sp(s0)
+
+	/* Save user stack value. Coming from user space, we know this
+	 * can't overflow the privileged stack. The esf will be allocated
+	 * later but it is safe to store our saved user sp here. */
+	sr t0, (-__struct_arch_esf_SIZEOF + __struct_arch_esf_sp_OFFSET)(sp)
+
+	/* Make sure tls pointer is sane */
+	lr t0, ___cpu_t_current_OFFSET(s0)
+	lr tp, _thread_offset_to_tls(t0)
+
+	/* Make sure global pointer is sane */
+#ifdef CONFIG_RISCV_GP
+	.option push
+	.option norelax
+	la gp, __global_pointer$
+	.option pop
+#elif defined(CONFIG_RISCV_CURRENT_VIA_GP)
+	lr gp, ___cpu_t_current_OFFSET(s0)
+#endif /* CONFIG_RISCV_GP / CONFIG_RISCV_CURRENT_VIA_GP */
+
+	/* Clear our per-thread usermode flag */
+	lui t0, %tprel_hi(is_user_mode)
+	add t0, t0, tp, %tprel_add(is_user_mode)
+	sb zero, %tprel_lo(is_user_mode)(t0)
+1:
+	/* retrieve original t0/t1 values */
+	lr t0, _curr_cpu_arch_user_exc_tmp0(s0)
+	lr t1, _curr_cpu_arch_user_exc_tmp1(s0)
+
+	/* retrieve original s0 and restore _current_cpu in mscratch */
+	csrrw s0, mscratch, s0
+#endif
+
+#ifdef CONFIG_RISCV_SOC_HAS_ISR_STACKING
+	SOC_ISR_SW_STACKING
+#else
+	/* Save caller-saved registers on current thread stack. */
+	addi sp, sp, -__struct_arch_esf_SIZEOF
+	DO_CALLER_SAVED(sr)		;
+#endif /* CONFIG_RISCV_SOC_HAS_ISR_STACKING */
+
+	/* Save s0 in the esf and load it with &_current_cpu. */
+	sr s0, __struct_arch_esf_s0_OFFSET(sp)
+	get_current_cpu s0
+
+#ifdef CONFIG_CLIC_SUPPORT_INTERRUPT_LEVEL
+	/* Save mcause register */
+	csrr t0, mcause
+	sr t0, __struct_arch_esf_mcause_OFFSET(sp)
+#endif /* CONFIG_CLIC_SUPPORT_INTERRUPT_LEVEL */
+
+	/* Save MEPC register */
+	csrr t0, mepc
+	sr t0, __struct_arch_esf_mepc_OFFSET(sp)
+
+	/* Save MSTATUS register */
+	csrr t2, mstatus
+	sr t2, __struct_arch_esf_mstatus_OFFSET(sp)
+
+#if defined(CONFIG_FPU_SHARING)
+	/* determine if FPU access was disabled */
+	li t1, MSTATUS_FS
+	and t1, t1, t2
+	bnez t1, no_fp
+	/* determine if this is an Illegal Instruction exception */
+	csrr t2, mcause
+	li t1, CONFIG_RISCV_MCAUSE_EXCEPTION_MASK
+	and t2, t2, t1
+	li t1, 2		/* 2 = illegal instruction */
+	bne t1, t2, no_fp
+	/* determine if we trapped on an FP instruction. */
+	csrr t2, mtval		/* get faulting instruction */
+#ifdef CONFIG_QEMU_TARGET
+	/*
+	 * Some implementations may not support MTVAL in this capacity.
+	 * Notably QEMU when a CSR instruction is involved.
+	 */
+	bnez t2, 1f
+	lw t2, 0(t0)		/* t0 = mepc */
+1:
+#endif
+	andi t0, t2, 0x7f	/* keep only the opcode bits */
+	/*
+	 * Major FP opcodes:
+	 * 0000111 = LOAD-FP
+	 * 0100111 = STORE-FP
+	 * 1000011 = MADD
+	 * 1000111 = MSUB
+	 * 1001011 = NMSUB
+	 * 1001111 = NMADD
+	 * 1010011 = OP-FP
+	 */
+	xori t1, t0, 0b1010011	/* OP-FP */
+	beqz t1, is_fp
+	ori  t1, t0, 0b0100000
+	xori t1, t1, 0b0100111	/* LOAD-FP / STORE-FP */
+	beqz t1, is_fp
+	ori  t1, t0, 0b0001100
+	xori t1, t1, 0b1001111	/* MADD / MSUB / NMSUB / NMADD */
+	beqz t1, is_fp
+	/*
+	 * The FRCSR, FSCSR, FRRM, FSRM, FSRMI, FRFLAGS, FSFLAGS and FSFLAGSI
+	 * are in fact CSR instructions targeting the fcsr, frm and fflags
+	 * registers. They should be caught as FPU instructions as well.
+	 *
+	 * CSR format: csr#[31-20] src[19-15] op[14-12] dst[11-7] SYSTEM[6-0]
+	 * SYSTEM = 0b1110011, op = 0b.xx where xx is never 0
+	 * The csr# of interest are: 1=fflags, 2=frm, 3=fcsr
+	 */
+	xori t1, t0, 0b1110011	/* SYSTEM opcode */
+	bnez t1, 2f		/* not a CSR insn */
+	srli t0, t2, 12
+	andi t0, t0, 0x3
+	beqz t0, 2f		/* not a CSR insn */
+	srli t0, t2, 20		/* isolate the csr register number */
+	beqz t0, 2f		/* 0=ustatus */
+	andi t0, t0, ~0x3	/* 1=fflags, 2=frm, 3=fcsr */
+#if !defined(CONFIG_RISCV_ISA_EXT_C)
+	bnez t0, no_fp
+#else
+	beqz t0, is_fp
+2:	/* remaining non RVC (0b11) and RVC with 0b01 are not FP instructions */
+	andi t1, t2, 1
+	bnez t1, no_fp
+	/*
+	 * 001...........00 = C.FLD    RV32/64  (RV128 = C.LQ)
+	 * 001...........10 = C.FLDSP  RV32/64  (RV128 = C.LQSP)
+	 * 011...........00 = C.FLW    RV32     (RV64/128 = C.LD)
+	 * 011...........10 = C.FLWSPP RV32     (RV64/128 = C.LDSP)
+	 * 101...........00 = C.FSD    RV32/64  (RV128 = C.SQ)
+	 * 101...........10 = C.FSDSP  RV32/64  (RV128 = C.SQSP)
+	 * 111...........00 = C.FSW    RV32     (RV64/128 = C.SD)
+	 * 111...........10 = C.FSWSP  RV32     (RV64/128 = C.SDSP)
+	 *
+	 * so must be .01............. on RV64 and ..1............. on RV32.
+	 */
+	srli t0, t2, 8
+#if defined(CONFIG_64BIT)
+	andi t1, t0, 0b01100000
+	xori t1, t1, 0b00100000
+	bnez t1, no_fp
+#else
+	andi t1, t0, 0b00100000
+	beqz t1, no_fp
+#endif
+#endif /* CONFIG_RISCV_ISA_EXT_C */
+
+is_fp:	/* Process the FP trap and quickly return from exception */
+	la ra, fp_trap_exit
+	mv a0, sp
+	tail z_riscv_fpu_trap
+2:
+no_fp:	/* increment _current->arch.exception_depth */
+	lr t0, ___cpu_t_current_OFFSET(s0)
+	lb t1, _thread_offset_to_exception_depth(t0)
+	add t1, t1, 1
+	sb t1, _thread_offset_to_exception_depth(t0)
+
+	/* configure the FPU for exception mode */
+	call z_riscv_fpu_enter_exc
+#endif /* CONFIG_FPU_SHARING */
+
+#ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
+	/* Handle context saving at SOC level. */
+	addi a0, sp, __struct_arch_esf_soc_context_OFFSET
+	jal ra, __soc_save_context
+#endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */
+
+#if defined(CONFIG_PMP_STACK_GUARD) && defined(CONFIG_MULTITHREADING)
+#ifdef CONFIG_USERSPACE
+	/*
+	 * If we came from userspace then we need to reconfigure the
+	 * PMP for kernel mode stack guard.
+	 */
+	lr t0, __struct_arch_esf_mstatus_OFFSET(sp)
+	li t1, MSTATUS_MPP
+	and t0, t0, t1
+	bnez t0, 1f
+	lr a0, ___cpu_t_current_OFFSET(s0)
+	call z_riscv_pmp_stackguard_enable
+	j 2f
+#endif /* CONFIG_USERSPACE */
+1:	/* Re-activate PMP for m-mode */
+	li t1, MSTATUS_MPP
+	csrc mstatus, t1
+	li t1, MSTATUS_MPRV
+	csrs mstatus, t1
+2:
+#endif
+
+	/* Increment _current_cpu->nested */
+	lw t1, ___cpu_t_nested_OFFSET(s0)
+	addi t2, t1, 1
+	sw t2, ___cpu_t_nested_OFFSET(s0)
+	bnez t1, on_irq_stack
+
+	/* Switch to interrupt stack */
+	mv t0, sp
+	lr sp, ___cpu_t_irq_stack_OFFSET(s0)
+
+	/*
+	 * Save thread stack pointer on interrupt stack
+	 * In RISC-V, stack pointer needs to be 16-byte aligned
+	 */
+	addi sp, sp, -16
+	sr t0, 0(sp)
+
+on_irq_stack:
+
+#ifdef CONFIG_RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING
+	call __soc_handle_all_irqs
+#else
+
+#ifdef CONFIG_TRACING_ISR
+	call sys_trace_isr_enter
+#endif
+
+	/* Get IRQ causing interrupt */
+	csrr a0, mcause
+	li t0, CONFIG_RISCV_MCAUSE_EXCEPTION_MASK
+	and a0, a0, t0
+
+	call _irq_vector_handler
+
+#ifdef CONFIG_TRACING_ISR
+	call sys_trace_isr_exit
+#endif
+
+#endif
+
+irq_done:
+	/* Decrement _current_cpu->nested */
+	lw t2, ___cpu_t_nested_OFFSET(s0)
+	addi t2, t2, -1
+	sw t2, ___cpu_t_nested_OFFSET(s0)
+	bnez t2, no_reschedule
+
+	/* nested count is back to 0: Return to thread stack */
+	lr sp, 0(sp)
+
+#ifdef CONFIG_STACK_SENTINEL
+	call z_check_stack_sentinel
+#endif
+
+check_reschedule:
+
+#ifdef CONFIG_MULTITHREADING
+
+	/* Get pointer to current thread on this CPU */
+	lr a1, ___cpu_t_current_OFFSET(s0)
+
+	/*
+	 * Get next thread to schedule with z_get_next_switch_handle().
+	 * We pass it a NULL as we didn't save the whole thread context yet.
+	 * If no scheduling is necessary then NULL will be returned.
+	 */
+	addi sp, sp, -16
+	sr a1, 0(sp)
+	mv a0, zero
+	call z_get_next_switch_handle
+	lr a1, 0(sp)
+	addi sp, sp, 16
+	beqz a0, no_reschedule
+
+reschedule:
+
+	/*
+	 * Perform context switch:
+	 * a0 = new thread
+	 * a1 = old thread
+	 */
+	call z_riscv_switch
+
+might_have_rescheduled:
+	/* reload s0 with &_current_cpu as it might have changed or be unset */
+	get_current_cpu s0
+
+#endif /* CONFIG_MULTITHREADING */
+
+no_reschedule:
+
+#ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
+	/* Restore context at SOC level */
+	addi a0, sp, __struct_arch_esf_soc_context_OFFSET
+	jal ra, __soc_restore_context
+#endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */
+
+#if defined(CONFIG_FPU_SHARING)
+	/* FPU handling upon exception mode exit */
+	mv a0, sp
+	call z_riscv_fpu_exit_exc
+
+	/* decrement _current->arch.exception_depth */
+	lr t0, ___cpu_t_current_OFFSET(s0)
+	lb t1, _thread_offset_to_exception_depth(t0)
+	add t1, t1, -1
+	sb t1, _thread_offset_to_exception_depth(t0)
+fp_trap_exit:
+#endif
+
+	/* Restore MEPC and MSTATUS registers */
+	lr t0, __struct_arch_esf_mepc_OFFSET(sp)
+	lr t2, __struct_arch_esf_mstatus_OFFSET(sp)
+
+#ifdef CONFIG_CLIC_SUPPORT_INTERRUPT_LEVEL
+	/* Restore MCAUSE register for previous interrupt level. */
+	lr t1, __struct_arch_esf_mcause_OFFSET(sp)
+	csrw mcause, t1
+#endif /* CONFIG_CLIC_SUPPORT_INTERRUPT_LEVEL */
+
+	csrw mepc, t0
+	csrw mstatus, t2
+
+#ifdef CONFIG_USERSPACE
+	/*
+	 * Check if we are returning to user mode. If so then we must
+	 * set is_user_mode to true and preserve our kernel mode stack for
+	 * the next exception to come.
+	 */
+	li t1, MSTATUS_MPP
+	and t0, t2, t1
+	bnez t0, 1f
+
+#if defined(CONFIG_PMP_STACK_GUARD) && defined(CONFIG_MULTITHREADING)
+	/* Remove kernel stack guard and Reconfigure PMP for user mode */
+	lr a0, ___cpu_t_current_OFFSET(s0)
+	call z_riscv_pmp_usermode_enable
+#endif
+
+	/* Set our per-thread usermode flag */
+	li t1, 1
+	lui t0, %tprel_hi(is_user_mode)
+	add t0, t0, tp, %tprel_add(is_user_mode)
+	sb t1, %tprel_lo(is_user_mode)(t0)
+
+	/* preserve stack pointer for next exception entry */
+	add t0, sp, __struct_arch_esf_SIZEOF
+	sr t0, _curr_cpu_arch_user_exc_sp(s0)
+
+	j 2f
+1:
+	/*
+	 * We are returning to kernel mode. Store the stack pointer to
+	 * be re-loaded further down.
+	 */
+	addi t0, sp, __struct_arch_esf_SIZEOF
+	sr t0, __struct_arch_esf_sp_OFFSET(sp)
+2:
+#endif
+
+	/* Restore s0 (it is no longer ours) */
+	lr s0, __struct_arch_esf_s0_OFFSET(sp)
+
+#ifdef CONFIG_RISCV_SOC_HAS_ISR_STACKING
+	SOC_ISR_SW_UNSTACKING
+#else
+	/* Restore caller-saved registers from thread stack */
+	DO_CALLER_SAVED(lr)
+
+#ifdef CONFIG_USERSPACE
+	/* retrieve saved stack pointer */
+	lr sp, __struct_arch_esf_sp_OFFSET(sp)
+#else
+	/* remove esf from the stack */
+	addi sp, sp, __struct_arch_esf_SIZEOF
+#endif
+
+#endif /* CONFIG_RISCV_SOC_HAS_ISR_STACKING */
+
+	mret

--- a/soc/telink/tlsr/telink_tlx/start.S
+++ b/soc/telink/tlsr/telink_tlx/start.S
@@ -7,8 +7,10 @@
 #define NDS_MCACHE_CTL               0x7ca
 #define NDS_MMISC_CTL                0x7d0
 #define NDS_UITB                     0x800
+#define PLIC_BASE_ADDRESS            DT_REG_ADDR(DT_NODELABEL(plic0))
 
 #include <zephyr/toolchain.h>
+#include <zephyr/devicetree.h>
 
 	.option push
 	.option norelax
@@ -40,13 +42,24 @@ start:
 	csrw   NDS_UITB, t0                     #/ CoDense instruction table
 #endif
 
-	/* Disable vector mode */
-	csrci  0x7d0, 2
+	/* Select PLIC mode */
+#ifdef CONFIG_RISCV_VECTORED_MODE
+	csrsi  NDS_MMISC_CTL, 2
+
+	/* Enable vector feture enable address */
+	lui    t0, %hi(PLIC_BASE_ADDRESS)
+	addi   t0, t0, %lo(PLIC_BASE_ADDRESS)
+	li     t1 ,0x03
+	sw     t1 ,0x0(t0)
+#else
+	csrci  NDS_MMISC_CTL, 2
 
 	/* Disable vector feture enable address */
-	lui    t0 ,0xc4000
+	lui    t0, %hi(PLIC_BASE_ADDRESS)
+	addi   t0, t0, %lo(PLIC_BASE_ADDRESS)
 	li     t1 ,0x00
 	sw     t1 ,0x0(t0)
+#endif /* CONFIG_RISCV_VECTORED_MODE */
 
 	/* Enable I/D-Cache */
 	csrr   t0, NDS_MCACHE_CTL
@@ -171,6 +184,25 @@ retention_entry:
 	.org 0x22
 
 retention_start:
+
+	/* Select PLIC mode */
+#ifdef CONFIG_RISCV_VECTORED_MODE
+	csrsi  NDS_MMISC_CTL, 2
+
+	/* Enable vector feture enable address */
+	lui    t0, %hi(PLIC_BASE_ADDRESS)
+	addi   t0, t0, %lo(PLIC_BASE_ADDRESS)
+	li     t1 ,0x03
+	sw     t1 ,0x0(t0)
+#else
+	csrci  NDS_MMISC_CTL, 2
+
+	/* Disable vector feture enable address */
+	lui    t0, %hi(PLIC_BASE_ADDRESS)
+	addi   t0, t0, %lo(PLIC_BASE_ADDRESS)
+	li     t1 ,0x00
+	sw     t1 ,0x0(t0)
+#endif /* CONFIG_RISCV_VECTORED_MODE */
 
 	/* Enable I/D-Cache */
 	csrr   t0, NDS_MCACHE_CTL

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 82ac7118d5e966169dd7939580ad51988c2ce1bd
+      revision: a30c76f17d65cec555b986380bbf4aa8c46bc396
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Telink TLx SOCs support nested interrupts functionality. It requires enabling vectored ISRs.