### PR TITLE
soc: telink: telink_w9x: Disable Branch prediction

### DIFF
--- a/soc/telink/tlsr/telink_w9x/blocking_core/blocking.c
+++ b/soc/telink/tlsr/telink_w9x/blocking_core/blocking.c
@@ -31,9 +31,7 @@ static void blocking_w91_request(const void *data, size_t len, void *param)
 	volatile uint32_t *blocking_state = (volatile uint32_t *)param;
 	uint32_t key = irq_lock();
 
-	__asm("csrci " STRINGIFY(NDS_MMISC_CTL) ", (1<<3)");
 	blocking_w91_wait(blocking_state);
-	__asm("csrsi " STRINGIFY(NDS_MMISC_CTL) ", (1<<3)");
 	irq_unlock(key);
 }
 

--- a/soc/telink/tlsr/telink_w9x/start.S
+++ b/soc/telink/tlsr/telink_w9x/start.S
@@ -99,8 +99,8 @@ _start_n22:
 	li     t0, 0x2
 	csrs   NDS_MCACHE_CTL, t0               #/ enable D-Cache
 #endif
-	li     t0, (1 << 6) | (1 << 3)
-	csrs   NDS_MMISC_CTL, t0                #/ Enable Misaligned access and branch prediction
+	li     t0, (1 << 6)
+	csrs   NDS_MMISC_CTL, t0                #/ Enable Misaligned access
 
 #if DT_HAS_CHOSEN(zephyr_aux_ram)
 


### PR DESCRIPTION
Bit BRPE in the CSR MMISC_CTL, which is responsible for Branch prediction enabling, is disabled due to unexpected random crashes observed on Matter project. The reason for now is not clear and requires investigation. So for now just disabling the feature to stabilize branch.