### PR TITLE
soc: telink: common: opus: fix decoder offset

### DIFF
--- a/soc/telink/tlsr/common/opus/opus.c
+++ b/soc/telink/tlsr/common/opus/opus.c
@@ -87,7 +87,8 @@ static void opus_decoder_work(struct k_work *item)
 {
 	struct opus_decoder *dec = CONTAINER_OF(item, struct opus_decoder, work);
 
-	int frames = tlka_opus_decode(dec->decoder, dec->inp.data, dec->inp.length, &dec->out[8],
+	int frames = tlka_opus_decode(dec->decoder, dec->inp.data, dec->inp.length,
+				      (opus_int16 *)((uint8_t *)dec->out + 8),
 				      dec->param.samples_per_frame, 0, dec->scratch);
 
 	if (frames != dec->param.samples_per_frame) {


### PR DESCRIPTION
in short: uint16_t -> uint8_t

Using tlka_opus_decode() with pointer arythmetic for reserved IPC attributes missed type casting which caused additional 8 zero bytes being placed at the beginning of the PCM buffer which corrupted playback.