### PR TITLE
soc: telink: common: opus: N22 revision for OPUS demo

### DIFF
--- a/soc/telink/tlsr/telink_w9x/Kconfig.n22
+++ b/soc/telink/tlsr/telink_w9x/Kconfig.n22
@@ -15,7 +15,7 @@ config TELINK_W91_FETCH_N22_BIN
 
 config TELINK_W91_FETCH_N22_BIN_REVISION
 	string "N22 binaries revision"
-	default "2a5b23e4ff3776ce714542b305587c6632a554c5"
+	default "820f5b0753d878fe1a66ef475e463524ef868f74"
 	depends on TELINK_W91_FETCH_N22_BIN
 	help
 		This option sets N22 binary revision.


### PR DESCRIPTION
Changed TELINK_W91_FETCH_N22_BIN_REVISION to be compatible with OPUS demo application.

To build OPUS demo application:
```
ZEPHYR_TOOLCHAIN_VARIANT=andes-gcc ANDES_GCC_PATH=/opt/nds32le-elf-newlib-v5f west build -b tlsr9118bdk40d_v1 -d build_opus samples/boards/tlsr9x/opus
```

NOTE: N22 side `tlsr9118_app_ipc_zephyr_defconfig` should contain `CONFIG_DEMO_OPUS=y`

Tested manually and on Jenkins: http://192.168.60.35:8080/job/Matter_build_Telink_examples/1146
