### PR TITLE
telink: Update AndeSight Toolchain

### DIFF
--- a/.github/workflows/telink-b91-build.yaml
+++ b/.github/workflows/telink-b91-build.yaml
@@ -39,7 +39,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b91_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b91.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-b91-nds-build.yaml
+++ b/.github/workflows/telink-b91-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b91_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b91.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-b92-build.yaml
+++ b/.github/workflows/telink-b92-build.yaml
@@ -39,7 +39,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b92_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b92.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-b92-nds-build.yaml
+++ b/.github/workflows/telink-b92-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b92_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_b92.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-tl321x-build.yaml
+++ b/.github/workflows/telink-tl321x-build.yaml
@@ -39,7 +39,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl321x_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl321x.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-tl321x-nds-build.yaml
+++ b/.github/workflows/telink-tl321x-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl321x_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl321x.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -39,7 +39,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl721x_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl721x.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-tl721x-nds-build.yaml
+++ b/.github/workflows/telink-tl721x-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         west init -l zephyr
         west update
         west blobs fetch hal_telink
-        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl721x_Os.a$' && exit 1
+        west blobs list hal_telink -f '{status} {path}' | grep '^M lib_zephyr_tl721x.a$' && exit 1
         west zephyr-export
         pip install -r zephyr/scripts/requirements.txt
 

--- a/.github/workflows/telink-w91-nds-build.yaml
+++ b/.github/workflows/telink-w91-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 1b49a548eba87a4e3c617de027e8c2a41a25d69b
+      revision: 0c2d784cb4d49a04878a22f5dda589605dd0d4c4
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Update from AndeSight v5.3.3 Toolchain (GCC 12.2) to AndeSight V5.4.1 Toolchain (GCC 14.2)