### PR TITLE
telink: Update AndeSight Toolchain

### DIFF
--- a/.github/workflows/telink-b91-nds-build.yaml
+++ b/.github/workflows/telink-b91-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3

--- a/.github/workflows/telink-b92-nds-build.yaml
+++ b/.github/workflows/telink-b92-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3

--- a/.github/workflows/telink-tl321x-nds-build.yaml
+++ b/.github/workflows/telink-tl321x-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3

--- a/.github/workflows/telink-tl721x-nds-build.yaml
+++ b/.github/workflows/telink-tl721x-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3

--- a/.github/workflows/telink-w91-nds-build.yaml
+++ b/.github/workflows/telink-w91-nds-build.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Setup Andes toolchain
       run: |
         mkdir ~/nds-gcc
-        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f.tar.gz
-        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f.tar.gz -C ~/nds-gcc
+        wget -q -P ~/nds-gcc https://doc.telink-semi.cn/Zephyr/binaries/public/tools/nds32le-elf-newlib-v5f_14.2.0.txz
+        tar xf ~/nds-gcc/nds32le-elf-newlib-v5f_14.2.0.txz -C ~/nds-gcc
 
     - name: Checkout Zephyr
       uses: actions/checkout@v3

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -34,16 +34,56 @@ if(NOT DEFINED NOSYSDEF_CFLAG)
   set(NOSYSDEF_CFLAG -undef)
 endif()
 
-foreach(file_name include/stddef.h include-fixed/limits.h)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}
-    OUTPUT_VARIABLE _OUTPUT
-    )
-  get_filename_component(_OUTPUT "${_OUTPUT}" DIRECTORY)
-  string(REGEX REPLACE "\n" "" _OUTPUT "${_OUTPUT}")
+# === GCC 13+/14 include-fixed handling ========================================
 
-  list(APPEND NOSTDINC ${_OUTPUT})
+# GCC 13+ no longer ships include-fixed/limits.h; pick the right header and make paths absolute
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} -dumpversion
+  OUTPUT_VARIABLE GCC_VER OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+set(_fix limits.h)
+if(${GCC_VER} VERSION_LESS 13)
+  set(_fix include-fixed/limits.h)
+else()
+  set(_fix include/limits.h)
+endif()
+
+foreach(_hdr include/stddef.h ${_fix})
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} --print-file-name=${_hdr}
+    OUTPUT_VARIABLE _p OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  get_filename_component(_d "${_p}" DIRECTORY)
+  if(IS_DIRECTORY "${_d}")
+    list(APPEND NOSTDINC "${_d}")
+  endif()
 endforeach()
+
+# Convert any relative implicit include dirs (e.g. "include-fixed") to absolute
+foreach(_var CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+  if(DEFINED ${_var})
+    set(_new "")
+    foreach(_dir IN LISTS ${_var})
+      if(IS_ABSOLUTE "${_dir}")
+        list(APPEND _new "${_dir}")
+      else()
+        execute_process(
+          COMMAND ${CMAKE_C_COMPILER} --print-file-name=${_dir}
+          OUTPUT_VARIABLE _abs OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        get_filename_component(_abs "${_abs}" DIRECTORY)
+        if(IS_DIRECTORY "${_abs}")
+          list(APPEND _new "${_abs}")
+        else()
+          list(APPEND _new "${_dir}")
+        endif()
+      endif()
+    endforeach()
+    set(${_var} "${_new}" CACHE INTERNAL "" FORCE)
+  endif()
+endforeach()
+
+# ============================================================================
 
 include(${ZEPHYR_BASE}/cmake/gcc-m-cpu.cmake)
 include(${ZEPHYR_BASE}/cmake/gcc-m-fpu.cmake)

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
         - hal
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 1b49a548eba87a4e3c617de027e8c2a41a25d69b
+      revision: 0c2d784cb4d49a04878a22f5dda589605dd0d4c4
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Update from AndeSight v5.3.3 Toolchain (GCC 12.2) to AndeSight V5.4.1 Toolchain (GCC 14.2)