### PR TITLE
Update W91 N22 binary revision, OPUS demo fix

### DIFF
--- a/soc/telink/tlsr/telink_w9x/Kconfig.n22
+++ b/soc/telink/tlsr/telink_w9x/Kconfig.n22
@@ -15,7 +15,7 @@ config TELINK_W91_FETCH_N22_BIN
 
 config TELINK_W91_FETCH_N22_BIN_REVISION
 	string "N22 binaries revision"
-	default "0274673a35327d2c822739fdc622f55fb226ffc8"
+	default "6b611375c98b5378caec2cc64bd257c487eb5f46"
 	depends on TELINK_W91_FETCH_N22_BIN
 	help
 		This option sets N22 binary revision.


### PR DESCRIPTION
After PM introduced for W91 it took more RAM and broke OPUS demo app.
We excluded PM by default for OPUS demo