### PR TITLE
drivers: ieee802154: telink: Fix adding enh-ack IE with zero length.

### DIFF
--- a/drivers/ieee802154/ieee802154_b9x.c
+++ b/drivers/ieee802154/ieee802154_b9x.c
@@ -48,12 +48,10 @@ static const struct device *flash_device =
 static struct b9x_src_match_table src_match_table;
 #endif /* CONFIG_OPENTHREAD_FTD */
 
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* B9X radio ACK table structure */
 static struct b9x_enh_ack_table enh_ack_table;
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 
-#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* mac keys data */
 static struct b9x_mac_keys mac_keys;
 #endif
@@ -63,10 +61,8 @@ static struct b9x_data data = {
 #ifdef CONFIG_OPENTHREAD_FTD
 	.src_match_table = &src_match_table,
 #endif /* CONFIG_OPENTHREAD_FTD */
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	.enh_ack_table = &enh_ack_table,
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
+	.enh_ack_table = &enh_ack_table,
 	/* mac keys data */
 	.mac_keys = &mac_keys,
 #endif
@@ -186,7 +182,7 @@ ALWAYS_INLINE b9x_require_pending_bit(const struct ieee802154_frame *frame)
 
 #endif /* CONFIG_OPENTHREAD_FTD */
 
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 
 /* clean radio search match table */
 static void b9x_enh_ack_table_clean(struct b9x_enh_ack_table *table)
@@ -262,10 +258,6 @@ static void b9x_enh_ack_table_remove(
 		}
 	}
 }
-
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
-
-#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 
 /* Clean mac keys data */
 static void b9x_mac_keys_data_clean(struct b9x_mac_keys *mac_keys_data)
@@ -740,7 +732,7 @@ static void ALWAYS_INLINE b9x_rf_rx_isr(const struct device *dev)
 			uint8_t *ack_ie_header = NULL;
 			size_t ack_ie_header_len = 0;
 			bool ack_se_bit = false;
-#if CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 			if (enh_ack) {
 				ack_se_bit = frame.general.se_bit ? true : false;
 				int idx = b9x_enh_ack_table_search(b9x->enh_ack_table,
@@ -754,7 +746,7 @@ static void ALWAYS_INLINE b9x_rf_rx_isr(const struct device *dev)
 						IEEE802154_FRAME_IE_HEADER_LENGTH;
 				}
 			}
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
+#endif
 			struct ieee802154_frame ack_frame = {
 				.general = {.valid = true,
 					    .ver = enh_ack ? IEEE802154_FRAME_FCF_VER_2015
@@ -973,11 +965,9 @@ static int b9x_init(const struct device *dev)
 	b9x_src_match_table_clean(b9x->src_match_table);
 	b9x->src_match_table->enabled = true;
 #endif /* CONFIG_OPENTHREAD_FTD */
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	b9x_enh_ack_table_clean(b9x->enh_ack_table);
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 	b9x->event_handler = NULL;
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
+	b9x_enh_ack_table_clean(b9x->enh_ack_table);
 	b9x_mac_keys_data_clean(b9x->mac_keys);
 #endif
 #ifdef CONFIG_OPENTHREAD_CSL_RECEIVER
@@ -1432,26 +1422,6 @@ static int b9x_configure(const struct device *dev,
 		}
 		break;
 #endif /* CONFIG_OPENTHREAD_FTD */
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE:
-		{
-			uint8_t short_addr[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
-			uint8_t ext_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
-
-			sys_put_le16(config->ack_ie.short_addr, short_addr);
-			sys_memcpy_swap(ext_addr, config->ack_ie.ext_addr,
-				IEEE802154_FRAME_LENGTH_ADDR_EXT);
-			if (!config->ack_ie.purge_ie) {
-				b9x_enh_ack_table_add(b9x->enh_ack_table,
-					short_addr, ext_addr,
-					config->ack_ie.header_ie);
-			} else {
-				b9x_enh_ack_table_remove(b9x->enh_ack_table,
-					short_addr, ext_addr);
-			}
-		}
-		break;
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #ifdef CONFIG_OPENTHREAD_CSL_RECEIVER
 		case IEEE802154_CONFIG_EXPECTED_RX_TIME: {
 			b9x->csl_sample_time_us = config->expected_rx_time / NSEC_PER_USEC;
@@ -1503,6 +1473,31 @@ static int b9x_configure(const struct device *dev,
 		break;
 	case IEEE802154_CONFIG_FRAME_COUNTER:
 		b9x->mac_keys->frame_cnt = config->frame_counter;
+		break;
+	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE:
+		{
+			uint8_t short_addr[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
+			uint8_t ext_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
+
+			sys_put_le16(config->ack_ie.short_addr, short_addr);
+			sys_memcpy_swap(ext_addr, config->ack_ie.ext_addr,
+				IEEE802154_FRAME_LENGTH_ADDR_EXT);
+			if (!config->ack_ie.purge_ie) {
+				if (config->ack_ie.header_ie &&
+					config->ack_ie.header_ie->length) {
+					b9x_enh_ack_table_add(b9x->enh_ack_table,
+						short_addr, ext_addr,
+						config->ack_ie.header_ie);
+				} else {
+					b9x_enh_ack_table_remove(b9x->enh_ack_table,
+						short_addr, ext_addr);
+				}
+
+			} else {
+				b9x_enh_ack_table_remove(b9x->enh_ack_table,
+					short_addr, ext_addr);
+			}
+		}
 		break;
 #endif
 	default:

--- a/drivers/ieee802154/ieee802154_b9x.h
+++ b/drivers/ieee802154/ieee802154_b9x.h
@@ -65,7 +65,7 @@ struct b9x_src_match_table {
 };
 #endif /* CONFIG_OPENTHREAD_FTD */
 
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* radio ACK table type */
 struct b9x_enh_ack_table {
 	struct {
@@ -75,9 +75,7 @@ struct b9x_enh_ack_table {
 		struct ieee802154_header_ie ie_header;
 	} item[CONFIG_OPENTHREAD_MAX_CHILDREN];
 };
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 
-#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* radio MAC keys type */
 struct b9x_mac_keys {
 	struct {
@@ -110,14 +108,12 @@ struct b9x_data {
 #ifdef CONFIG_OPENTHREAD_FTD
 	struct b9x_src_match_table *src_match_table;
 #endif /* CONFIG_OPENTHREAD_FTD */
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	struct b9x_enh_ack_table *enh_ack_table;
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #ifdef CONFIG_PM_DEVICE
 	atomic_t current_pm_lock;
 #endif /* CONFIG_PM_DEVICE */
 	ieee802154_event_cb_t event_handler;
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
+	struct b9x_enh_ack_table *enh_ack_table;
 	struct b9x_mac_keys *mac_keys;
 #endif
 #ifdef CONFIG_OPENTHREAD_CSL_RECEIVER

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -51,12 +51,10 @@ static const struct device *flash_device =
 static struct tlx_src_match_table src_match_table;
 #endif /* CONFIG_OPENTHREAD_FTD */
 
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* TLX radio ACK table structure */
 static struct tlx_enh_ack_table enh_ack_table;
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 
-#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* mac keys data */
 static struct tlx_mac_keys mac_keys;
 #endif
@@ -69,10 +67,8 @@ static struct tlx_data data = {
 #ifdef CONFIG_OPENTHREAD_FTD
 	.src_match_table = &src_match_table,
 #endif /* CONFIG_OPENTHREAD_FTD */
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	.enh_ack_table = &enh_ack_table,
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
+	.enh_ack_table = &enh_ack_table,
 	/* mac keys data */
 	.mac_keys = &mac_keys,
 #endif
@@ -197,7 +193,7 @@ ALWAYS_INLINE tlx_require_pending_bit(const struct ieee802154_frame *frame)
 
 #endif /* CONFIG_OPENTHREAD_FTD */
 
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 
 /* clean radio search match table */
 static void tlx_enh_ack_table_clean(struct tlx_enh_ack_table *table)
@@ -273,10 +269,6 @@ static void tlx_enh_ack_table_remove(
 		}
 	}
 }
-
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
-
-#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 
 /* Clean mac keys data */
 static void tlx_mac_keys_data_clean(struct tlx_mac_keys *mac_keys_data)
@@ -756,7 +748,7 @@ static void ALWAYS_INLINE tlx_rf_rx_isr(const struct device *dev)
 			uint8_t *ack_ie_header = NULL;
 			size_t ack_ie_header_len = 0;
 			bool ack_se_bit = false;
-#if CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 			if (enh_ack) {
 				ack_se_bit = frame.general.se_bit ? true : false;
 				int idx = tlx_enh_ack_table_search(tlx->enh_ack_table,
@@ -770,7 +762,7 @@ static void ALWAYS_INLINE tlx_rf_rx_isr(const struct device *dev)
 						IEEE802154_FRAME_IE_HEADER_LENGTH;
 				}
 			}
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
+#endif
 			struct ieee802154_frame ack_frame = {
 				.general = {.valid = true,
 					    .ver = enh_ack ? IEEE802154_FRAME_FCF_VER_2015
@@ -1006,11 +998,9 @@ static int tlx_init(const struct device *dev)
 	tlx_src_match_table_clean(tlx->src_match_table);
 	tlx->src_match_table->enabled = true;
 #endif /* CONFIG_OPENTHREAD_FTD */
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	tlx_enh_ack_table_clean(tlx->enh_ack_table);
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 	tlx->event_handler = NULL;
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
+	tlx_enh_ack_table_clean(tlx->enh_ack_table);
 	tlx_mac_keys_data_clean(tlx->mac_keys);
 #endif
 #ifdef CONFIG_OPENTHREAD_CSL_RECEIVER
@@ -1503,26 +1493,6 @@ static int tlx_configure(const struct device *dev,
 		}
 		break;
 #endif /* CONFIG_OPENTHREAD_FTD */
-#if CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE:
-		{
-			uint8_t short_addr[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
-			uint8_t ext_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
-
-			sys_put_le16(config->ack_ie.short_addr, short_addr);
-			sys_memcpy_swap(ext_addr, config->ack_ie.ext_addr,
-				IEEE802154_FRAME_LENGTH_ADDR_EXT);
-			if (!config->ack_ie.purge_ie) {
-				tlx_enh_ack_table_add(tlx->enh_ack_table,
-					short_addr, ext_addr,
-					config->ack_ie.header_ie);
-			} else {
-				tlx_enh_ack_table_remove(tlx->enh_ack_table,
-					short_addr, ext_addr);
-			}
-		}
-		break;
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #ifdef CONFIG_OPENTHREAD_CSL_RECEIVER
 		case IEEE802154_CONFIG_EXPECTED_RX_TIME: {
 			tlx->csl_sample_time_us = config->expected_rx_time / NSEC_PER_USEC;
@@ -1574,6 +1544,31 @@ static int tlx_configure(const struct device *dev,
 		break;
 	case IEEE802154_CONFIG_FRAME_COUNTER:
 		tlx->mac_keys->frame_cnt = config->frame_counter;
+		break;
+	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE:
+		{
+			uint8_t short_addr[IEEE802154_FRAME_LENGTH_ADDR_SHORT];
+			uint8_t ext_addr[IEEE802154_FRAME_LENGTH_ADDR_EXT];
+
+			sys_put_le16(config->ack_ie.short_addr, short_addr);
+			sys_memcpy_swap(ext_addr, config->ack_ie.ext_addr,
+				IEEE802154_FRAME_LENGTH_ADDR_EXT);
+			if (!config->ack_ie.purge_ie) {
+				if (config->ack_ie.header_ie &&
+					config->ack_ie.header_ie->length) {
+					tlx_enh_ack_table_add(tlx->enh_ack_table,
+						short_addr, ext_addr,
+						config->ack_ie.header_ie);
+				} else {
+					tlx_enh_ack_table_remove(tlx->enh_ack_table,
+						short_addr, ext_addr);
+				}
+
+			} else {
+				tlx_enh_ack_table_remove(tlx->enh_ack_table,
+					short_addr, ext_addr);
+			}
+		}
 		break;
 #endif
 	default:

--- a/drivers/ieee802154/ieee802154_tlx.h
+++ b/drivers/ieee802154/ieee802154_tlx.h
@@ -65,7 +65,7 @@ struct tlx_src_match_table {
 };
 #endif /* CONFIG_OPENTHREAD_FTD */
 
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* radio ACK table type */
 struct tlx_enh_ack_table {
 	struct {
@@ -75,9 +75,7 @@ struct tlx_enh_ack_table {
 		struct ieee802154_header_ie ie_header;
 	} item[CONFIG_OPENTHREAD_MAX_CHILDREN];
 };
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 
-#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 /* radio MAC keys type */
 struct tlx_mac_keys {
 	struct {
@@ -116,14 +114,12 @@ struct tlx_data {
 #ifdef CONFIG_OPENTHREAD_FTD
 	struct tlx_src_match_table *src_match_table;
 #endif /* CONFIG_OPENTHREAD_FTD */
-#ifdef CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT
-	struct tlx_enh_ack_table *enh_ack_table;
-#endif /* CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT */
 #ifdef CONFIG_PM_DEVICE
 	atomic_t current_pm_lock;
 #endif /* CONFIG_PM_DEVICE */
 	ieee802154_event_cb_t event_handler;
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
+	struct tlx_enh_ack_table *enh_ack_table;
 	struct tlx_mac_keys *mac_keys;
 #endif
 #ifdef CONFIG_OPENTHREAD_CSL_RECEIVER


### PR DESCRIPTION
- Check whether the enh-ack IE length is 0 and whether the structure is null before injection.
- Update some macros switches for enh-ack table code blocks.