### PR TITLE
drivers: interrupt_controller: intc_plic.c: Fix ISR number

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -27,7 +27,7 @@
 #define PLIC_REG	DT_INST_REG_ADDR_BY_NAME(0, reg)
 
 #define PLIC_IRQS        (CONFIG_NUM_IRQS - CONFIG_2ND_LVL_ISR_TBL_OFFSET)
-#define PLIC_EN_SIZE     ((PLIC_IRQS >> 5) + 1)
+#define PLIC_EN_SIZE     ((PLIC_IRQS + 31) >> 5)
 
 struct plic_regs_t {
 	uint32_t threshold_prio;
@@ -189,7 +189,7 @@ static int plic_init(void)
 
 	/* Set priority of each interrupt line to 0 initially */
 	prio++; /* no zero ISR, it's reserved for PLIC features */
-	for (i = 0; i < PLIC_IRQS; i++) {
+	for (i = 1; i < PLIC_IRQS; i++) {
 		*prio = 0U;
 		prio++;
 	}

--- a/soc/riscv/riscv-privilege/telink_b9x/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b9x/Kconfig.defconfig.series
@@ -34,7 +34,8 @@ config RISCV_GP
 
 config NUM_IRQS
 	int
-	default 59
+	default 59 if SOC_RISCV_TELINK_B92
+	default 76 if SOC_RISCV_TELINK_B91
 
 config 2ND_LVL_ISR_TBL_OFFSET
 	int

--- a/soc/riscv/riscv-privilege/telink_tlx/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_tlx/Kconfig.defconfig.series
@@ -38,7 +38,8 @@ config RISCV_GP
 
 config NUM_IRQS
 	int
-	default 65
+	default 65 if SOC_RISCV_TELINK_TL721X
+	default 65 if SOC_RISCV_TELINK_TL321X
 
 config 2ND_LVL_ISR_TBL_OFFSET
 	int


### PR DESCRIPTION
On RISC-V platform zero PLIC ISR is for features.
in Zephyr CONFIG_NUM_IRQS under RISC-V represents number PLIC IRQ inputs (including reserved zero) plus number core ISRs.