### PR TITLE
kconfig: update N22 binary revision (Opus demo CI)

### DIFF
--- a/soc/telink/tlsr/telink_w9x/Kconfig.n22
+++ b/soc/telink/tlsr/telink_w9x/Kconfig.n22
@@ -15,7 +15,7 @@ config TELINK_W91_FETCH_N22_BIN
 
 config TELINK_W91_FETCH_N22_BIN_REVISION
 	string "N22 binaries revision"
-	default "e2d19032a4dce0455325186d6a71650142477bfc"
+	default "02505ff9ae825cbb5d1884b6d323ffa82c85b726"
 	depends on TELINK_W91_FETCH_N22_BIN
 	help
 		This option sets N22 binary revision.


### PR DESCRIPTION
Updated N22 binary hash after Opus migration.
This commit contains CI build fix for N22 binary.