### PR TITLE
soc: telink: tlsr: power.c: Fix external interrupts

### DIFF
--- a/soc/telink/tlsr/telink_b9x/power.c
+++ b/soc/telink/tlsr/telink_b9x/power.c
@@ -144,7 +144,10 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(substate_id);
 
 #if CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION
-	b9x_deep_sleep_retention = false;
+	if (b9x_deep_sleep_retention) {
+		csr_clear(mip, MIP_MEIP);
+		b9x_deep_sleep_retention = false;
+	}
 #endif
 
 	/*

--- a/soc/telink/tlsr/telink_tlx/power.c
+++ b/soc/telink/tlsr/telink_tlx/power.c
@@ -144,7 +144,10 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(substate_id);
 
 #if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
-	tlx_deep_sleep_retention = false;
+	if (tlx_deep_sleep_retention) {
+		csr_clear(mip, MIP_MEIP);
+		tlx_deep_sleep_retention = false;
+	}
 #endif
 
 	/*


### PR DESCRIPTION
During stress test was observed that CLINT external interrupt is set during restoring peripheral from deep-sleep mode, in that case PLIC state is clean (no any external interrupts detected). The mechanism is not clean since between peripheral devices and CLINT there is PLIC. So seldom device triggers external interrupt directly without PLIC which shouldn't be possible. Seems to be HW issue.