### PR TITLE
riscv: telink: fix secondary slot size handling with LZMA

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -71,7 +71,7 @@ function(zephyr_mcuboot_tasks)
 
   # If single slot mode, or if in firmware updater mode and this is the firmware updater image,
   # use slot 0 information
-  if(NOT CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP AND (NOT CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER OR CONFIG_MCUBOOT_APPLICATION_FIRMWARE_UPDATER))
+  if(NOT CONFIG_COMPRESS_LZMA AND NOT CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP AND (NOT CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER OR CONFIG_MCUBOOT_APPLICATION_FIRMWARE_UPDATER))
     # Slot 1 size is used instead of slot 0 size
     set(slot_size)
     dt_nodelabel(slot1_flash NODELABEL "slot1_partition" REQUIRED)

--- a/soc/telink/tlsr/telink_b9x/mcu_boot_lzma.c
+++ b/soc/telink/tlsr/telink_b9x/mcu_boot_lzma.c
@@ -219,7 +219,16 @@ int __wrap_boot_slots_compatible(struct boot_loader_state *state)
 			smaller = 1;
 			i++;
 		} else {
-			sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+			size_t sector_size = boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+
+			if (sector_size == 0) {
+				/* Since this supports decompressed images,
+				 * we can safely exit if slot1 is smaller than slot0.
+				 */
+				break;
+			}
+
+			sz1 += sector_size;
 			/* Guarantee that multiple sectors of the primary slot
 			 * fit into the secondary slot.
 			 */

--- a/soc/telink/tlsr/telink_tlx/mcu_boot_lzma.c
+++ b/soc/telink/tlsr/telink_tlx/mcu_boot_lzma.c
@@ -219,7 +219,16 @@ int __wrap_boot_slots_compatible(struct boot_loader_state *state)
 			smaller = 1;
 			i++;
 		} else {
-			sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+			size_t sector_size = boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+
+			if (sector_size == 0) {
+				/* Since this supports decompressed images,
+				 * we can safely exit if slot1 is smaller than slot0.
+				 */
+				break;
+			}
+
+			sz1 += sector_size;
 			/* Guarantee that multiple sectors of the primary slot
 			 * fit into the secondary slot.
 			 */


### PR DESCRIPTION
Regression appears after upgrading to Zephyr 4.1.
The issue occurs when the secondary slot is smaller than zephyr.bin but valid for compressed image.