### PR TITLE
hal: telink: kconfig option for HW SHA for TLx

### DIFF
--- a/soc/telink/tlsr/telink_tlx/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_tlx/CMakeLists.txt
@@ -70,7 +70,7 @@ zephyr_link_libraries(
 )
 
 # Make MCUBoot early boot code injection
-if (CONFIG_TELINK_B9X_MCUBOOT_STARTUP)
+if (CONFIG_TELINK_TLX_MCUBOOT_STARTUP)
 
 zephyr_sources(
 	mcu_boot_startup.c

--- a/soc/telink/tlsr/telink_tlx/Kconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig
@@ -49,6 +49,14 @@ config TELINK_TLX_MBEDTLS_HW_ACCELERATION
 	help
 		This option enables Telink TLx hardware accelerated mbedtls version.
 
+config TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION
+	bool "Use Telink TLx platform mbedtls HW SHA256 acceleration"
+	depends on TELINK_TLX_MBEDTLS_HW_ACCELERATION
+	default y if MCUBOOT
+	help
+		This option enables Telink TLx hardware accelerated
+		SHA256 for MbedTLS in bootloader only.
+
 config TELINK_SOC_REBOOT_ON_FAULT
 	bool "Reboot system when fault happened"
 	help

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 7423b7127120a507976d4da5fc7a1b2ee31ec173
+      revision: 736ee87e6235fd202cb224158b60f7e9ee4f36c9
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Change in hal_telink speeds up validation time of MCUBoot slots x3, from ~5-6sec to <2sec in Matter application boot.
More info: [hal_telink PR](https://github.com/telink-semi/hal_telink/pull/165)

Also small typo fix in tlx/soc