### PR TITLE
telink: New HAL Telink structure

### DIFF
--- a/soc/telink/tlsr/Kconfig.soc
+++ b/soc/telink/tlsr/Kconfig.soc
@@ -40,6 +40,18 @@ config SOC_RISCV_TELINK_TL721X
 	help
 	  Telink TL721X
 
+config SOC_RISCV_TELINK_TL322X
+	bool "Telink TL322 SoC implementation"
+	select SOC_RISCV_TELINK_TLX
+	help
+	  Telink TL322X
+
+config SOC_RISCV_TELINK_TL323X
+	bool "Telink TL323 SoC implementation"
+	select SOC_RISCV_TELINK_TLX
+	help
+	  Telink TL323X
+
 endchoice
 
 config SOC_FAMILY_TELINK_TLSR

--- a/soc/telink/tlsr/soc.yml
+++ b/soc/telink/tlsr/soc.yml
@@ -12,3 +12,5 @@ family:
         socs:
           - name: telink_tl321x
           - name: telink_tl721x
+          - name: telink_tl322x
+          - name: telink_tl323x

--- a/soc/telink/tlsr/telink_tlx/Kconfig.soc
+++ b/soc/telink/tlsr/telink_tlx/Kconfig.soc
@@ -13,3 +13,5 @@ config SOC_SERIES
 config SOC
 	default "telink_tl321x" if SOC_RISCV_TELINK_TL321X
 	default "telink_tl721x" if SOC_RISCV_TELINK_TL721X
+	default "telink_tl322x" if SOC_RISCV_TELINK_TL322X
+	default "telink_tl323x" if SOC_RISCV_TELINK_TL323X

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 0c2d784cb4d49a04878a22f5dda589605dd0d4c4
+      revision: 7423b7127120a507976d4da5fc7a1b2ee31ec173
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Due to new Telink SOCs (TL322, TL323) new HAL structure is introduced.
For now Kconfigs for TL322, TL323 SOCs are added just for compliance.