### PR TITLE
telink: fix tlx_adc acquisition frozen in deep sleep

### DIFF
--- a/drivers/adc/adc_tlx.c
+++ b/drivers/adc/adc_tlx.c
@@ -20,6 +20,9 @@ LOG_MODULE_REGISTER(adc_tlx, CONFIG_ADC_LOG_LEVEL);
 /* Telink HAL headers */
 #include <adc.h>
 #include <zephyr/drivers/pinctrl.h>
+#ifdef CONFIG_PM_DEVICE
+#include <zephyr/pm/device.h>
+#endif /* CONFIG_PM_DEVICE */
 
 /* Set ADC resolution value */
 static inline void adc_set_resolution(adc_res_e res)
@@ -52,6 +55,16 @@ struct tlx_adc_cfg {
 	uint16_t vref_internal_mv;
 	const struct pinctrl_dev_config *pcfg;
 };
+
+#ifdef CONFIG_PM_DEVICE
+struct adc_tlx_state {
+	struct tlx_adc_cfg adc_cfg;
+	struct tlx_adc_data adc_data;
+	struct adc_channel_cfg channel_cfg;
+};
+
+static struct adc_tlx_state adc_state;
+#endif /* CONFIG_PM_DEVICE */
 
 /* Validate ADC data buffer size */
 static int adc_tlx_validate_buffer_size(const struct adc_sequence *sequence)
@@ -435,6 +448,9 @@ static int adc_tlx_channel_setup(const struct device *dev,
 #endif
 	}
 
+#ifdef CONFIG_PM_DEVICE
+	memcpy(&adc_state.channel_cfg, channel_cfg, sizeof(struct adc_channel_cfg));
+#endif
 	return 0;
 }
 
@@ -469,6 +485,44 @@ static int adc_tlx_read_async(const struct device *dev,
 }
 #endif /* CONFIG_ADC_ASYNC */
 
+#ifdef CONFIG_PM_DEVICE
+__GENERIC_SECTION(.ram_code)
+static int adc_tlx_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct tlx_adc_data *data = dev->data;
+	struct tlx_adc_cfg *cfg = dev->config;
+
+	extern volatile bool tlx_deep_sleep_retention;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+	{
+		if (tlx_deep_sleep_retention) {
+			memcpy(cfg, &adc_state.adc_cfg, sizeof(struct tlx_adc_cfg));
+			memcpy(data, &adc_state.adc_data, sizeof(struct tlx_adc_data));
+
+			adc_tlx_channel_setup(dev, &adc_state.channel_cfg);
+		}
+	}
+	break;
+
+	case PM_DEVICE_ACTION_SUSPEND:
+	{
+		memcpy(&adc_state.adc_cfg, cfg, sizeof(struct tlx_adc_cfg));
+		memcpy(&adc_state.adc_data, data, sizeof(struct tlx_adc_data));
+	}
+	break;
+
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+PM_DEVICE_DT_INST_DEFINE(0, adc_tlx_pm_action);
+#endif /* CONFIG_PM_DEVICE */
+
 static struct tlx_adc_data data_0 = {
 	ADC_CONTEXT_INIT_TIMER(data_0, ctx),
 	ADC_CONTEXT_INIT_LOCK(data_0, ctx),
@@ -492,7 +546,7 @@ static const struct adc_driver_api adc_tlx_driver_api = {
 	.ref_internal = cfg_0.vref_internal_mv,
 };
 
-DEVICE_DT_INST_DEFINE(0, adc_tlx_init, NULL,
+DEVICE_DT_INST_DEFINE(0, adc_tlx_init, PM_DEVICE_DT_INST_GET(0),
 		      &data_0,  &cfg_0,
 		      POST_KERNEL,
 		      CONFIG_ADC_INIT_PRIORITY,

--- a/drivers/adc/adc_tlx.c
+++ b/drivers/adc/adc_tlx.c
@@ -57,13 +57,7 @@ struct tlx_adc_cfg {
 };
 
 #ifdef CONFIG_PM_DEVICE
-struct adc_tlx_state {
-	struct tlx_adc_cfg adc_cfg;
-	struct tlx_adc_data adc_data;
-	struct adc_channel_cfg channel_cfg;
-};
-
-static struct adc_tlx_state adc_state;
+struct adc_channel_cfg tlx_channel_cfg;
 #endif /* CONFIG_PM_DEVICE */
 
 /* Validate ADC data buffer size */
@@ -449,7 +443,7 @@ static int adc_tlx_channel_setup(const struct device *dev,
 	}
 
 #ifdef CONFIG_PM_DEVICE
-	memcpy(&adc_state.channel_cfg, channel_cfg, sizeof(struct adc_channel_cfg));
+	memcpy(&tlx_channel_cfg, channel_cfg, sizeof(struct adc_channel_cfg));
 #endif
 	return 0;
 }
@@ -489,27 +483,20 @@ static int adc_tlx_read_async(const struct device *dev,
 __GENERIC_SECTION(.ram_code)
 static int adc_tlx_pm_action(const struct device *dev, enum pm_device_action action)
 {
-	struct tlx_adc_data *data = dev->data;
-	struct tlx_adc_cfg *cfg = dev->config;
-
 	extern volatile bool tlx_deep_sleep_retention;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 	{
 		if (tlx_deep_sleep_retention) {
-			memcpy(cfg, &adc_state.adc_cfg, sizeof(struct tlx_adc_cfg));
-			memcpy(data, &adc_state.adc_data, sizeof(struct tlx_adc_data));
-
-			adc_tlx_channel_setup(dev, &adc_state.channel_cfg);
+			adc_tlx_channel_setup(dev, &tlx_channel_cfg);
 		}
 	}
 	break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
 	{
-		memcpy(&adc_state.adc_cfg, cfg, sizeof(struct tlx_adc_cfg));
-		memcpy(&adc_state.adc_data, data, sizeof(struct tlx_adc_data));
+
 	}
 	break;
 

--- a/samples/drivers/adc/adc_dt/boards/tl3218x_retention.overlay
+++ b/samples/drivers/adc/adc_dt/boards/tl3218x_retention.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Telink Semiconductor (Shanghai) Co., Ltd.
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc 0>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <DT_ADC_VBAT>;
+	};
+};


### PR DESCRIPTION
 - Add the config and data restore when PM is awakened .