### PR TITLE
telink: fix tlx_i2c acquisition frozen in deep sleep

### DIFF
--- a/drivers/i2c/i2c_tlx.c
+++ b/drivers/i2c/i2c_tlx.c
@@ -15,6 +15,9 @@ LOG_MODULE_REGISTER(i2c_telink);
 #include <zephyr/drivers/i2c.h>
 #include "i2c-priv.h"
 #include <zephyr/drivers/pinctrl.h>
+#ifdef CONFIG_PM_DEVICE
+#include <zephyr/pm/device.h>
+#endif /* CONFIG_PM_DEVICE */
 
 /* I2C configuration structure */
 struct i2c_tlx_cfg {
@@ -154,6 +157,40 @@ static int i2c_tlx_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+__GENERIC_SECTION(.ram_code)
+static int i2c_tlx_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct i2c_tlx_cfg *cfg = dev->config;
+	uint32_t dev_config = (I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(cfg->bitrate));
+
+	extern volatile bool tlx_deep_sleep_retention;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+	{
+		if (tlx_deep_sleep_retention) {
+			i2c_tlx_configure(dev, dev_config);
+		}
+	}
+	break;
+
+	case PM_DEVICE_ACTION_SUSPEND:
+	{
+
+	}
+	break;
+
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+PM_DEVICE_DT_INST_DEFINE(0, i2c_tlx_pm_action);
+#endif /* CONFIG_PM_DEVICE */
+
 /* I2C driver APIs structure */
 static const struct i2c_driver_api i2c_tlx_api = {
 	.configure = i2c_tlx_configure,
@@ -176,7 +213,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 	};							      \
 								      \
 	I2C_DEVICE_DT_INST_DEFINE(inst, i2c_tlx_init,		      \
-				  NULL,				      \
+				  PM_DEVICE_DT_INST_GET(0),				      \
 				  &i2c_tlx_data_##inst,		      \
 				  &i2c_tlx_cfg_##inst,		      \
 				  POST_KERNEL,			      \

--- a/samples/sensor/sht3xd/boards/tl3218x_retention.overlay
+++ b/samples/sensor/sht3xd/boards/tl3218x_retention.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/tl321x-pinctrl.h>
+
+/ {
+	keys {
+		/delete-node/ button_1;
+		compatible = "gpio-keys";
+		key_1: button_1 {
+			gpios = <&gpiob 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		};
+	};
+};
+
+&pinctrl {
+	/* Define I2C pins: SCL(PC3), SDA(PC2) */
+
+	i2c_scl_pc3_default: i2c_scl_pc3_default {
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_3, TL321X_FUNC_I2C_SCL_IO)>;
+		bias-pull-up;
+	};
+	i2c_sda_pc2_default: i2c_sda_pc2_default {
+		pinmux = <TLX_PINMUX_SET(TLX_PORT_C, TLX_PIN_2, TL321X_FUNC_I2C_SDA_IO)>;
+		bias-pull-up;
+	};
+};
+
+&i2c {
+	pinctrl-0 = <&i2c_scl_pc3_default &i2c_sda_pc2_default>;
+
+	sht3xd@44 {
+		compatible = "sensirion,sht3xd";
+		reg = <0x44>;
+	};
+};


### PR DESCRIPTION
 - Restore i2c_tlx_configure when PM is awakened .