### PR TITLE
telink: tl323x: output the chip ID when RX is grounded.

### DIFF
--- a/soc/telink/tlsr/telink_tlx/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_tlx/CMakeLists.txt
@@ -74,7 +74,7 @@ zephyr_link_libraries(
 )
 
 # Make MCUBoot early boot code injection
-if (CONFIG_TELINK_B9X_MCUBOOT_STARTUP)
+if (CONFIG_TELINK_TLX_MCUBOOT_STARTUP)
 
 zephyr_sources(
 	mcu_boot_startup.c

--- a/soc/telink/tlsr/telink_tlx/Kconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig
@@ -124,6 +124,8 @@ config TELINK_TLX_MCUBOOT_STARTUP
 	depends on MCUBOOT
 	select CRC
 	select UART_DRV_CMD
+	default y if SOC_RISCV_TELINK_TL323X
+	default n
 	help
 		Run Telink specific vendor code before MCUBoot
 		main process

--- a/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
+++ b/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
@@ -69,8 +69,10 @@ static bool telink_tlx_mcu_boot_startup(void)
 		uint8_t chip_id[21] = {0};
 		uint8_t ieee_addr[8] = {0};
 		if (efuse_get_ieee_addr(ieee_addr) == DRV_API_SUCCESS) {
+
 			memcpy(chip_id + 2, ieee_addr, 8);
 			uint16_t chip_id_crc = crc16_itu_t(0, chip_id + 2, 16);
+
 			chip_id[0] = 0xaa;
 			chip_id[1] = 0x12;
 			chip_id[18] = chip_id_crc & 0x00ff;

--- a/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
+++ b/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
@@ -8,14 +8,20 @@
 #include <zephyr/drivers/uart.h>
 #include <bootutil/bootutil_log.h>
 #include <zephyr/sys/crc.h>
-BOOT_LOG_MODULE_REGISTER(telink_b9x_mcuboot);
 
-static bool telink_b9x_mcu_boot_startup(void);
-static __maybe_unused void printk_buf(const char *comment, void *buf, size_t buf_len);
+#if CONFIG_SOC_RISCV_TELINK_TL323X
+#include "efuse.h"
+#include "gpio.h"
+#include <zephyr/dt-bindings/pinctrl/tl323x-pinctrl.h>
+#endif
+
+BOOT_LOG_MODULE_REGISTER(telink_tlx_mcuboot);
+
+static bool telink_tlx_mcu_boot_startup(void);
 
 void __wrap_main(void)
 {
-	if (telink_b9x_mcu_boot_startup()) {
+	if (telink_tlx_mcu_boot_startup()) {
 		extern void __real_main(void);
 
 		__real_main();
@@ -23,55 +29,65 @@ void __wrap_main(void)
 }
 
 /* Vendor specific code during MCUBoot startup */
-static bool telink_b9x_mcu_boot_startup(void)
+static bool telink_tlx_mcu_boot_startup(void)
 {
 	bool result = true; /* run MCUBoot main */
 
-	BOOT_LOG_INF("telink B9x MCUBoot on early boot");
-#if CONFIG_SOC_RISCV_TELINK_B92
+#if CONFIG_SOC_RISCV_TELINK_TL323X
 	bool show_chip_id = false;
 
 	/* Check if Console UART RX line is at low level - shorted to ground */
 	const struct device *const uart_con = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (device_is_ready(uart_con)) {
-		/* Get UART pins count shorted to ground */
-		int pins_gnd = uart_drv_cmd(uart_con, 0, 0);
 
-		if (pins_gnd >= 0) {
-			if (pins_gnd > 0) {
-				show_chip_id = true;
-			}
-		} else {
-			BOOT_LOG_ERR("can't count uart shorted to GND pins");
+	/* Use the uart corresponding to your zephyr_console configuration */
+		#define UART_RX_PINMUX \
+			DT_PROP(DT_PINCTRL_BY_IDX(DT_NODELABEL(uart0), 0, 1), pinmux)
+		gpio_pin_e uart_rx = TLX_PINMUX_GET_PIN(UART_RX_PINMUX);
+
+		/* Disable The UART RX PIN */
+		gpio_set_low_level(uart_rx);
+		gpio_output_dis(uart_rx);
+		gpio_function_dis(uart_rx);
+
+		/* Enable The UART RX PIN GPIO Function */
+		gpio_function_en(uart_rx);
+		gpio_input_en(uart_rx);
+		gpio_set_up_down_res(uart_rx, GPIO_PIN_PULLUP_10K);
+
+		/* Check if Console UART RX PIN is at low level - shorted to ground */
+		if (gpio_get_level(uart_rx) == 0) {
+			show_chip_id = true;
 		}
 	} else {
 		BOOT_LOG_ERR("uart console not ready");
 	}
 
 	if (show_chip_id) {
-		extern unsigned char efuse_get_chip_id(unsigned char *chip_id_buff);
-		uint8_t chip_id[18];
-
-		if (efuse_get_chip_id(chip_id)) {
-			uint16_t chip_id_crc = crc16_itu_t(0, chip_id, 16);
-
-			chip_id[16] = chip_id_crc & 0x00ff;
-			chip_id[17] = chip_id_crc >> 8;
-			printk_buf("chip id", chip_id, sizeof(chip_id));
+		extern drv_api_status_e efuse_get_ieee_addr(unsigned char *chip_id_buff);
+		uint8_t chip_id[21] = {0};
+		uint8_t ieee_addr[8] = {0};
+		if (efuse_get_ieee_addr(ieee_addr) == DRV_API_SUCCESS) {
+			memcpy(chip_id + 2, ieee_addr, 8);
+			uint16_t chip_id_crc = crc16_itu_t(0, chip_id + 2, 16);
+			chip_id[0] = 0xaa;
+			chip_id[1] = 0x12;
+			chip_id[18] = chip_id_crc & 0x00ff;
+			chip_id[19] = chip_id_crc >> 8;
+			chip_id[20] = 0x55;
+			print_buffer(chip_id, sizeof(chip_id));
 		} else {
 			BOOT_LOG_ERR("chip id read error");
 		}
 	}
-#endif /* CONFIG_SOC_RISCV_TELINK_B92 */
+#endif /* CONFIG_SOC_RISCV_TELINK_TL323X */
 	return result;
 }
 
-static __maybe_unused void printk_buf(const char *comment, void *buf, size_t buf_len)
+void print_buffer(uint8_t *buffer, size_t size)
 {
-	printk("%s[%u]:", comment, buf_len);
-	for (size_t i = 0; i < buf_len; ++i) {
-		printk(" %02x", ((uint8_t *)buf)[i]);
+	for (size_t i = 0; i < size; i++) {
+		printk("%c", buffer[i]);
 	}
-	printk("\n");
 }


### PR DESCRIPTION
- RX pin PB3 on the TL3238C board is missing and needs to be replaced with another pin.
- set CONFIG_BOOT_BANNER=n on the matter side.