### PR TITLE
telink: fix i2c pin not be restored in deep sleep

### DIFF
--- a/drivers/adc/adc_tlx.c
+++ b/drivers/adc/adc_tlx.c
@@ -483,20 +483,23 @@ static int adc_tlx_read_async(const struct device *dev,
 __GENERIC_SECTION(.ram_code)
 static int adc_tlx_pm_action(const struct device *dev, enum pm_device_action action)
 {
-	extern volatile bool tlx_deep_sleep_retention;
-
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 	{
+#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+		extern volatile bool tlx_deep_sleep_retention;
 		if (tlx_deep_sleep_retention) {
 			adc_tlx_channel_setup(dev, &tlx_channel_cfg);
 		}
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 	}
 	break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
 	{
+#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
 
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 	}
 	break;
 

--- a/drivers/i2c/i2c_tlx.c
+++ b/drivers/i2c/i2c_tlx.c
@@ -162,22 +162,31 @@ __GENERIC_SECTION(.ram_code)
 static int i2c_tlx_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	const struct i2c_tlx_cfg *cfg = dev->config;
+	const pinctrl_soc_pin_t *i2cPinsMux = cfg->pcfg->states->pins;
 	uint32_t dev_config = (I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(cfg->bitrate));
-
-	extern volatile bool tlx_deep_sleep_retention;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 	{
+#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+		extern volatile bool tlx_deep_sleep_retention;
 		if (tlx_deep_sleep_retention) {
 			i2c_tlx_configure(dev, dev_config);
 		}
+
+		pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		/* Enable the input function of the SCL and SDA pins */
+		gpio_input_en(*i2cPinsMux++);
+		gpio_input_en(*i2cPinsMux);
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 	}
 	break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
 	{
-
+#if CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+		gpio_shutdown(*i2cPinsMux);
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 	}
 	break;
 


### PR DESCRIPTION
 - Restore i2cPinsMux when PM is awakened .