### PR TITLE
telink: tl3238x: rm adc thread create

### DIFF
--- a/drivers/adc/adc_tl323x.c
+++ b/drivers/adc/adc_tl323x.c
@@ -432,14 +432,14 @@ static int adc_tl323x_init(const struct device *dev)
     }
 
 	k_sem_init(&data->acq_sem, 0, 1);
-
+#if 0
 	k_thread_create(&data->thread, data->stack,
 		CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE,
 		(k_thread_entry_t)adc_tl323x_acquisition_thread,
 		(void *)dev, NULL, NULL,
 		CONFIG_ADC_TL323X_ACQUISITION_THREAD_PRIO,
 		0, K_NO_WAIT);
-
+#endif
 	adc_context_unlock_unconditionally(&data->ctx);
 
 	return 0;

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -503,6 +503,14 @@ static void plic_irq_handler(const struct device *dev)
 	uint32_t cpu_id = arch_curr_cpu()->id;
 	/* Get the IRQ number generating the interrupt */
 	const uint32_t local_irq = sys_read32(claim_complete_addr);
+#if (CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION || CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION)
+	/* Workaround for Telink SOCs to aviod IRQ11 */
+	if (!local_irq) {
+		extern void telink_zero_isr(void);
+		telink_zero_isr();
+		return;
+	}
+#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION || CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 
 #ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 	uint16_t *cpu_count = get_irq_hit_count_cpu(dev, cpu_id, local_irq);

--- a/soc/telink/tlsr/telink_b9x/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_b9x/CMakeLists.txt
@@ -28,6 +28,10 @@ zephyr_sources_ifdef(CONFIG_MCUBOOT_ACTION_HOOKS
 	mcuboot_status_change.c
 )
 
+zephyr_sources_ifdef(CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION
+	soc_irq0.c
+)
+
 # Force using BFD-LD
 zephyr_ld_options(-fuse-ld=bfd)
 

--- a/soc/telink/tlsr/telink_b9x/soc_irq0.c
+++ b/soc/telink/tlsr/telink_b9x/soc_irq0.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(telink, CONFIG_KERNEL_LOG_LEVEL);
+
+void telink_zero_isr(void)
+{
+	LOG_WRN("PLIC zero isr");
+}

--- a/soc/telink/tlsr/telink_tlx/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_tlx/CMakeLists.txt
@@ -36,6 +36,10 @@ zephyr_sources_ifdef(CONFIG_MCUBOOT_ACTION_HOOKS
 	mcuboot_status_change.c
 )
 
+zephyr_sources_ifdef(CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+	soc_irq0.c
+)
+
 # Force using BFD-LD
 zephyr_ld_options(-fuse-ld=bfd)
 

--- a/soc/telink/tlsr/telink_tlx/soc_irq0.c
+++ b/soc/telink/tlsr/telink_tlx/soc_irq0.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(telink, CONFIG_KERNEL_LOG_LEVEL);
+
+void telink_zero_isr(void)
+{
+	LOG_WRN("PLIC zero isr");
+}


### PR DESCRIPTION
 - To save resources, the ADC thread will not be created because the user is not using it. .