### PR TITLE
telink: tlsr9268j: early startup proc cluster info

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -830,6 +830,15 @@ FUNC_NORETURN void z_cstart(void)
 #endif
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_2);
 
+#ifndef CONFIG_MCUBOOT
+	typedef void (*p_early_proc)(void);
+	extern p_early_proc early_proc_cluster_f;
+
+	if (early_proc_cluster_f != NULL) {
+		early_proc_cluster_f();
+	}
+#endif
+
 #ifdef CONFIG_REQUIRES_STACK_CANARIES
 	uintptr_t stack_guard;
 

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 703c97e20e014bcb236cc18a5d5ab521780679ca
+      revision: 2a2d9d7d23971dd1b2d6d6d6968da91ed20bce6a
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
 - Add cluster info proc to be in front of POST_KERNEL .
 - Update the hal commit in west.yml .