### PR TITLE
include: zephyr: net: net_if.h: Fix struct net_if_addr

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -125,6 +125,7 @@ struct net_if_addr {
 			uint8_t acd_state;
 		};
 #endif /* CONFIG_NET_IPV4_ACD */
+		uint8_t _dummy;
 	};
 
 #if defined(CONFIG_NET_IPV6_DAD) || defined(CONFIG_NET_IPV4_ACD)


### PR DESCRIPTION
Make struct net_if_addr same for c and c++.
If both configs CONFIG_NET_IPV6_DAD and CONFIG_NET_IPV4_ACD are not defined we got empty union. The size of empty storage in c is zero whilst in c++ one.