### PR TITLE
Develop tl3238x develop link

### DIFF
--- a/drivers/adc/adc_tl323x.c
+++ b/drivers/adc/adc_tl323x.c
@@ -35,7 +35,7 @@ struct tl323x_adc_data {
 	struct k_thread thread;
     uint8_t mode;
 
-	/* To save resources, the ADC thread will not be created because the user is not using it. */
+	/* To save resources, the ADC thread will not be created because the user is not using */
 	/* K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE); */
 };
 
@@ -433,13 +433,14 @@ static int adc_tl323x_init(const struct device *dev)
     }
 
 	k_sem_init(&data->acq_sem, 0, 1);
-	/* To save resources, the ADC thread will not be created because the user is not using it. */
+	/* To save resources, the ADC thread will not be created because the user is not using */
 	/* k_thread_create(&data->thread, data->stack,
 		CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE,
 		(k_thread_entry_t)adc_tl323x_acquisition_thread,
 		(void *)dev, NULL, NULL,
 		CONFIG_ADC_TL323X_ACQUISITION_THREAD_PRIO,
-		0, K_NO_WAIT); */
+		0, K_NO_WAIT);
+	*/
 	adc_context_unlock_unconditionally(&data->ctx);
 
 	return 0;

--- a/drivers/adc/adc_tl323x.c
+++ b/drivers/adc/adc_tl323x.c
@@ -35,7 +35,11 @@ struct tl323x_adc_data {
 	struct k_thread thread;
     uint8_t mode;
 
-	K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE);
+	/*
+	 *	To save resources, the ADC thread will not be created 
+	 *	because the user is not using it .
+	 */
+	// K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE);
 };
 
 /* Driver configuration structure */
@@ -432,14 +436,16 @@ static int adc_tl323x_init(const struct device *dev)
     }
 
 	k_sem_init(&data->acq_sem, 0, 1);
-
-	k_thread_create(&data->thread, data->stack,
-		CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE,
-		(k_thread_entry_t)adc_tl323x_acquisition_thread,
-		(void *)dev, NULL, NULL,
-		CONFIG_ADC_TL323X_ACQUISITION_THREAD_PRIO,
-		0, K_NO_WAIT);
-
+	/*
+	 *	To save resources, the ADC thread will not be created 
+	 *	because the user is not using it .
+	 */
+	// k_thread_create(&data->thread, data->stack,
+	// 	CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE,
+	// 	(k_thread_entry_t)adc_tl323x_acquisition_thread,
+	// 	(void *)dev, NULL, NULL,
+	// 	CONFIG_ADC_TL323X_ACQUISITION_THREAD_PRIO,
+	// 	0, K_NO_WAIT);
 	adc_context_unlock_unconditionally(&data->ctx);
 
 	return 0;

--- a/drivers/adc/adc_tl323x.c
+++ b/drivers/adc/adc_tl323x.c
@@ -35,11 +35,8 @@ struct tl323x_adc_data {
 	struct k_thread thread;
     uint8_t mode;
 
-	/*
-	 *	To save resources, the ADC thread will not be created 
-	 *	because the user is not using it .
-	 */
-	// K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE);
+	/* To save resources, the ADC thread will not be created because the user is not using it. */
+	/* K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE); */
 };
 
 /* Driver configuration structure */
@@ -436,16 +433,13 @@ static int adc_tl323x_init(const struct device *dev)
     }
 
 	k_sem_init(&data->acq_sem, 0, 1);
-	/*
-	 *	To save resources, the ADC thread will not be created 
-	 *	because the user is not using it .
-	 */
-	// k_thread_create(&data->thread, data->stack,
-	// 	CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE,
-	// 	(k_thread_entry_t)adc_tl323x_acquisition_thread,
-	// 	(void *)dev, NULL, NULL,
-	// 	CONFIG_ADC_TL323X_ACQUISITION_THREAD_PRIO,
-	// 	0, K_NO_WAIT);
+	/* To save resources, the ADC thread will not be created because the user is not using it. */
+	/* k_thread_create(&data->thread, data->stack,
+		CONFIG_ADC_TL323X_ACQUISITION_THREAD_STACK_SIZE,
+		(k_thread_entry_t)adc_tl323x_acquisition_thread,
+		(void *)dev, NULL, NULL,
+		CONFIG_ADC_TL323X_ACQUISITION_THREAD_PRIO,
+		0, K_NO_WAIT); */
 	adc_context_unlock_unconditionally(&data->ctx);
 
 	return 0;

--- a/soc/telink/tlsr/telink_tlx/matter_retention.ld
+++ b/soc/telink/tlsr/telink_tlx/matter_retention.ld
@@ -31,18 +31,6 @@ SECTION_DATA_PROLOGUE(ram_dlm_bss,(NOLOAD),)
 	 */
 	"*malloc.c.obj*"(".noinit.*")
 
-	/* Moving the BLE controller stack (HAL) */
-	"*tlx_bt.c.obj*"(".noinit.*" ".bss.*")
-
-	/* Moving the Zephyr BLE data */
-	"*att.c.obj*"(".noinit.*" ".bss.*")
-	"*buf.c.obj*"(".noinit.*")
-	"*conn.c.obj*"(".noinit.*" ".bss.*")
-	"*crypto.c.obj*"(".bss.*")
-	"*gatt.c.obj*"(".bss.*")
-	"*hci_core.c.obj*"(".noinit.*" ".bss.*")
-	"*l2cap.c.obj*"(".bss.*")
-
 	PROVIDE (_RAM_DLM_BSS_VMA_END = .);
 	PROVIDE (_RAM_DLM_BSS_VMA_START = ADDR(ram_dlm_bss));
 	PROVIDE (_RAM_DLM_BSS_LMA_START = LOADADDR(ram_dlm_bss));


### PR DESCRIPTION
 - Moving the BLE controller stack form ram_dlm_bss .
 - To save resources, the ADC thread will not be created because the user is not using it .