### PR TITLE
Develop tl3238x hw acc

### DIFF
--- a/soc/telink/tlsr/telink_tlx/Kconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig
@@ -70,6 +70,14 @@ config TELINK_TLX_MBEDTLS_HW_ACCELERATION
 	help
 		This option enables Telink TLx hardware accelerated mbedtls version.
 
+config TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION
+	bool "Use Telink TLx platform mbedtls HW SHA256 acceleration"
+	depends on TELINK_TLX_MBEDTLS_HW_ACCELERATION
+	default y if MCUBOOT
+	help
+		This option enables Telink TLx hardware accelerated
+		SHA256 for MbedTLS in bootloader only.
+
 config TELINK_SOC_REBOOT_ON_FAULT
 	bool "Reboot system when fault happened"
 	help

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: pull/176/head
+      revision: 15e9eafed405ce6b1b958072be972238a75a647d
       path: modules/hal/telink
       groups:
         - hal
@@ -309,7 +309,7 @@ manifest:
         - crypto
     - name: mcuboot
       url: https://github.com/telink-semi/mcuboot
-      revision: pull/13/head
+      revision: f7154f087dd0dd7243043ed7308c85d31863eb36
       path: bootloader/mcuboot
       groups:
         - bootloader

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: e6911e81de08886da806d2241cecb74e94978c07
+      revision: pull/176/head
       path: modules/hal/telink
       groups:
         - hal
@@ -309,7 +309,7 @@ manifest:
         - crypto
     - name: mcuboot
       url: https://github.com/telink-semi/mcuboot
-      revision: 92ec50eb718031a243ac30b9f5463ee6be1b5603
+      revision: pull/13/head
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
hal: telink: kconfig option for HW SHA for TLx

Change in hal_telink speeds up validation time of MCUBoot
slots x3, from ~5-6sec to <2sec in Matter application boot.

Also small typo fix in tlx/soc

Signed-off-by: Dmytro Huz <diman1436@gmail.com>

- update mcuboot and hal_telink revision
- set CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE in bootloader conf
file to enable read APP FW directly
- Apply https://github.com/telink-semi/zephyr/commit/23c8c1c52df01d0b93debf5aaae193973b462f3f to tl323x and set
TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION to y by default

Note that only RSA keypair takes effect becaude it select MBEDTLS.
However, ECDSA keypair will use TinyCryto so it does not use the HW Hash Acceleration APIs.