### PR TITLE
net: if: Add dummy member to anonymous union in net_if_addr

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -125,6 +125,7 @@ struct net_if_addr {
 			uint8_t acd_state;
 		};
 #endif /* CONFIG_NET_IPV4_ACD */
+		uint8_t _dummy;
 	};
 
 #if defined(CONFIG_NET_IPV6_DAD) || defined(CONFIG_NET_IPV4_ACD)


### PR DESCRIPTION
When both CONFIG_NET_IPV6_DAD and CONFIG_NET_IPV4_ACD are disabled, the anonymous union in struct net_if_addr ends up with no members, which results in a different struct layout between C and C++.

In C, an empty union has size 0, while in C++ it has size >=1, which shifts the offsets of the following fields.

Add a 1-byte dummy member to the union to ensure consistent layout across both compilers.