### PR TITLE
soc: telink: tlsr: Rework SHA HW cryptography

### DIFF
--- a/soc/telink/tlsr/telink_b9x/Kconfig
+++ b/soc/telink/tlsr/telink_b9x/Kconfig
@@ -39,10 +39,17 @@ config TELINK_B9X_PFT
 
 config TELINK_B9X_MBEDTLS_HW_ACCELERATION
 	bool "Use Telink B9x platform mbedtls HW acceleration"
-	depends on MBEDTLS
+	depends on MBEDTLS || BOOTLOADER_MCUBOOT
 	default y
 	help
-		This option enables Telink B9x hardware accelerated mbedtls version
+		This option enables Telink B9x hardware accelerated mbedtls version.
+
+config TELINK_B9X_TINYCRYPT_HW_ACCELERATION
+	bool "Use Telink B9x platform tinycrypt HW acceleration"
+	depends on TINYCRYPT || BOOTLOADER_MCUBOOT
+	default y
+	help
+		This option enables Telink B9x hardware accelerated tinycrypt version.
 
 config TELINK_SOC_REBOOT_ON_FAULT
 	bool "Reboot system when fault happened"

--- a/soc/telink/tlsr/telink_tlx/Kconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig
@@ -44,18 +44,17 @@ config TELINK_TLX_PFT
 
 config TELINK_TLX_MBEDTLS_HW_ACCELERATION
 	bool "Use Telink TLx platform mbedtls HW acceleration"
-	depends on MBEDTLS
+	depends on MBEDTLS || BOOTLOADER_MCUBOOT
 	default y
 	help
 		This option enables Telink TLx hardware accelerated mbedtls version.
 
-config TELINK_TLX_MBEDTLS_HW_SHA_ACCELERATION
-	bool "Use Telink TLx platform mbedtls HW SHA256 acceleration"
-	depends on TELINK_TLX_MBEDTLS_HW_ACCELERATION
-	default y if MCUBOOT
+config TELINK_TLX_TINYCRYPT_HW_ACCELERATION
+	bool "Use Telink TLx platform tinycrypt HW acceleration"
+	depends on TINYCRYPT || BOOTLOADER_MCUBOOT
+	default y
 	help
-		This option enables Telink TLx hardware accelerated
-		SHA256 for MbedTLS in bootloader only.
+		This option enables Telink TLx hardware accelerated tinycrypt version.
 
 config TELINK_SOC_REBOOT_ON_FAULT
 	bool "Reboot system when fault happened"

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 1f54d883f96f9a287d2a610473389f22cb8fa7e1
+      revision: b70112010f8482ea9c476d2c702d40c100ddc95f
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
Reworked Telink SHA calculation using HW unit on TLX platforms:
- support MbedTLS & Tinycrypt
- fix multithread & power management