### PR TITLE
soc: telink: tlsr: telink_x: Kconfig: Fix Kconfig dependencies

### DIFF
--- a/soc/telink/tlsr/telink_b9x/Kconfig
+++ b/soc/telink/tlsr/telink_b9x/Kconfig
@@ -37,16 +37,24 @@ config TELINK_B9X_PFT
 	default y
 	select RISCV_SOC_CONTEXT_SAVE
 
+# To pass CI on Zephyr 4.1
+config BOOT_USE_MBEDTLS
+	bool
+
 config TELINK_B9X_MBEDTLS_HW_ACCELERATION
 	bool "Use Telink B9x platform mbedtls HW acceleration"
-	depends on MBEDTLS || BOOTLOADER_MCUBOOT
+	depends on MBEDTLS || BOOT_USE_MBEDTLS
 	default y
 	help
 		This option enables Telink B9x hardware accelerated mbedtls version.
 
+# To pass CI on Zephyr 4.1
+config BOOT_USE_TINYCRYPT
+	bool
+
 config TELINK_B9X_TINYCRYPT_HW_ACCELERATION
 	bool "Use Telink B9x platform tinycrypt HW acceleration"
-	depends on TINYCRYPT || BOOTLOADER_MCUBOOT
+	depends on TINYCRYPT || BOOT_USE_TINYCRYPT
 	default y
 	help
 		This option enables Telink B9x hardware accelerated tinycrypt version.

--- a/soc/telink/tlsr/telink_tlx/Kconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig
@@ -42,16 +42,24 @@ config TELINK_TLX_PFT
 	default y
 	select RISCV_SOC_CONTEXT_SAVE
 
+# To pass CI on Zephyr 4.1
+config BOOT_USE_MBEDTLS
+	bool
+
 config TELINK_TLX_MBEDTLS_HW_ACCELERATION
 	bool "Use Telink TLx platform mbedtls HW acceleration"
-	depends on MBEDTLS || BOOTLOADER_MCUBOOT
+	depends on MBEDTLS || BOOT_USE_MBEDTLS
 	default y
 	help
 		This option enables Telink TLx hardware accelerated mbedtls version.
 
+# To pass CI on Zephyr 4.1
+config BOOT_USE_TINYCRYPT
+	bool
+
 config TELINK_TLX_TINYCRYPT_HW_ACCELERATION
 	bool "Use Telink TLx platform tinycrypt HW acceleration"
-	depends on TINYCRYPT || BOOTLOADER_MCUBOOT
+	depends on TINYCRYPT || BOOT_USE_TINYCRYPT
 	default y
 	help
 		This option enables Telink TLx hardware accelerated tinycrypt version.


### PR DESCRIPTION
Fixed dependency for bootloader HW cryptography on Telink B9X & TLX platforms.