### PR TITLE
telink: tl3238x: fix bug and clean clock

### DIFF
--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/storage/flash_map.h>
+#include "tlx_bt.h"
 
 #if DEBUG_GPIO_ENABLE
 #include "gpio_default.h"
@@ -290,6 +291,18 @@ void soc_early_init_hook(void)
 
 	/* system init */
 	sys_init(POWER_MODE, VBAT_TYPE, INTERNAL_CAP_XTAL24M);
+
+	/* Only need for lighting to switch from zigbee to matter */
+#if CONFIG_SOC_RISCV_TELINK_TL323X && !CONFIG_PM && !CONFIG_MCUBOOT
+	/* Enable clock before operate rf register */
+	rf_mode_init();
+	/* Reset Radio */
+	rf_radio_reset();
+	rf_reset_dma();
+	rf_baseband_reset();
+
+	rf_clr_irq_status(FLD_RF_IRQ_ALL);
+#endif /* CONFIG_SOC_RISCV_TELINK_TL323X && !CONFIG_PM && !CONFIG_MCUBOOT */
 
 #if CONFIG_SOC_RISCV_TELINK_TL721X
 	if (cclk == CLK_240MHZ) {

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -201,7 +201,7 @@ void soc_load_rf_parameters_deep_retention(void)
 #endif
 
 #if CONFIG_PM
-#define RST_BIT_CLR(x, n)    ((x) |= (n))
+#define RST_BIT_CLR(x, n)    ((x) &=~(n))
 #define CLOCK_BIT_CLR(x, n)    ((x) &=~(n))
 __attribute__((noinline)) __attribute__((section(".ram_code"))) __attribute__((optimize("O2")))
 void gen_fsk_close_unused_clock(void)
@@ -215,18 +215,13 @@ void gen_fsk_close_unused_clock(void)
     RST_BIT_CLR(reg_rst1, FLD_RST1_SPISLV);
     
     RST_BIT_CLR(reg_rst2, FLD_RST2_I2C1);
-	RST_BIT_CLR(reg_rst2, FLD_RST2_LM);
 	RST_BIT_CLR(reg_rst2, FLD_RST2_TRNG);
     
     RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC1);
-	RST_BIT_CLR(reg_rst3, FLD_RST3_TRACE);
 	RST_BIT_CLR(reg_rst3, FLD_RST3_BROM);
     RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC);
     
-    RST_BIT_CLR(reg_rst4, FLD_RST4_DC);
     RST_BIT_CLR(reg_rst4, FLD_RST4_UART4);
-    RST_BIT_CLR(reg_rst4, FLD_RST4_SKE);
-    RST_BIT_CLR(reg_rst4, FLD_RST4_HASH);	// will enable when HW HASH used
     
     RST_BIT_CLR(reg_rst5, FLD_RST5_UART2);
     RST_BIT_CLR(reg_rst5, FLD_RST5_PEM);
@@ -247,14 +242,10 @@ void gen_fsk_close_unused_clock(void)
 	CLOCK_BIT_CLR(reg_clk_en2, FLD_CLK2_I2C1_EN);
 
 	CLOCK_BIT_CLR(reg_clk_en3, FLD_CLK3_QDEC1_EN);
-	CLOCK_BIT_CLR(reg_clk_en3, FLD_CLK3_TRACE_EN);
 	CLOCK_BIT_CLR(reg_clk_en3, FLD_CLK3_BROM_EN);
 	CLOCK_BIT_CLR(reg_clk_en3, FLD_CLK3_QDEC0_EN);
 
-	CLOCK_BIT_CLR(reg_clk_en4, FLD_CLK4_DC_EN);
 	CLOCK_BIT_CLR(reg_clk_en4, FLD_CLK4_UART4_EN);
-	CLOCK_BIT_CLR(reg_clk_en4, FLD_CLK4_SKE_EN);
-	CLOCK_BIT_CLR(reg_clk_en4, FLD_CLK4_HASH_EN);	// will enable when HW HASH used
 
 	CLOCK_BIT_CLR(reg_clk_en5, FLD_CLK5_UART2_EN);
 	CLOCK_BIT_CLR(reg_clk_en5, FLD_CLK5_PEM_EN);

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 15e9eafed405ce6b1b958072be972238a75a647d
+      revision: 68f4d9ace874c2248a81cd30c6e59cf51e9174f9
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
 - Reset rf related registers in soc_early_init_hook .
 - Update rst and clock clear on tl323x pm .
 - Update the hal commit .