### PR TITLE
soc: telink: add PLIC interrupt controller support

### DIFF
--- a/drivers/entropy/entropy_tlx_trng.c
+++ b/drivers/entropy/entropy_tlx_trng.c
@@ -12,7 +12,7 @@
 
 
 /* API implementation: driver initialization */
-static int entropy_b9x_trng_init(const struct device *dev)
+static int entropy_tlx_trng_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
@@ -22,7 +22,7 @@ static int entropy_b9x_trng_init(const struct device *dev)
 }
 
 /* API implementation: get_entropy */
-static int entropy_b9x_trng_get_entropy(const struct device *dev,
+static int entropy_tlx_trng_get_entropy(const struct device *dev,
 					uint8_t *buffer, uint16_t length)
 {
 	ARG_UNUSED(dev);
@@ -46,26 +46,26 @@ static int entropy_b9x_trng_get_entropy(const struct device *dev,
 }
 
 /* API implementation: get_entropy_isr */
-static int entropy_b9x_trng_get_entropy_isr(const struct device *dev,
+static int entropy_tlx_trng_get_entropy_isr(const struct device *dev,
 					    uint8_t *buffer, uint16_t length,
 					    uint32_t flags)
 {
 	ARG_UNUSED(flags);
 
 	/* No specific handling in case of running from ISR, just call standard API */
-	entropy_b9x_trng_get_entropy(dev, buffer, length);
+	entropy_tlx_trng_get_entropy(dev, buffer, length);
 
 	return 0;
 }
 
 /* Entropy driver APIs structure */
-static const struct entropy_driver_api entropy_b9x_trng_api = {
-	.get_entropy = entropy_b9x_trng_get_entropy,
-	.get_entropy_isr = entropy_b9x_trng_get_entropy_isr
+static const struct entropy_driver_api entropy_tlx_trng_api = {
+	.get_entropy = entropy_tlx_trng_get_entropy,
+	.get_entropy_isr = entropy_tlx_trng_get_entropy_isr
 };
 
 /* Entropy driver registration */
-DEVICE_DT_INST_DEFINE(0, entropy_b9x_trng_init,
+DEVICE_DT_INST_DEFINE(0, entropy_tlx_trng_init,
 		      NULL, NULL, NULL,
 		      PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
-		      &entropy_b9x_trng_api);
+		      &entropy_tlx_trng_api);

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -34,6 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_NUCLEI_ECLIC            intc_nuclei_eclic.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_S32_EIRQ            intc_eirq_nxp_s32.c)
 zephyr_library_sources_ifdef(CONFIG_XMC4XXX_INTC            intc_xmc4xxx.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_PINT                intc_nxp_pint.c)
+zephyr_library_sources_ifdef(CONFIG_PLIC_TELINK             intc_telink_plic.c)
 
 if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -100,4 +100,6 @@ source "drivers/interrupt_controller/Kconfig.xmc4xxx"
 
 source "drivers/interrupt_controller/Kconfig.nxp_pint"
 
+source "drivers/interrupt_controller/Kconfig.telink"
+
 endmenu

--- a/drivers/interrupt_controller/Kconfig.telink
+++ b/drivers/interrupt_controller/Kconfig.telink
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+config PLIC_TELINK
+	bool "Telink Interrupt Controller (PLIC)"
+	default y
+	depends on DT_HAS_TELINK_PLIC_ENABLED
+	select MULTI_LEVEL_INTERRUPTS
+	select 2ND_LEVEL_INTERRUPTS
+	help
+	  Platform Level Interrupt Controller provides support
+	  for external interrupt lines defined by the RISC-V SoC.

--- a/drivers/interrupt_controller/intc_telink_plic.c
+++ b/drivers/interrupt_controller/intc_telink_plic.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT sifive_plic_1_0_0
+#define DT_DRV_COMPAT telink_plic
 
 /**
  * @brief Platform Level Interrupt Controller (PLIC) driver
@@ -27,7 +27,7 @@
 #define PLIC_REG	DT_INST_REG_ADDR_BY_NAME(0, reg)
 
 #define PLIC_IRQS        (CONFIG_NUM_IRQS - CONFIG_2ND_LVL_ISR_TBL_OFFSET)
-#define PLIC_EN_SIZE     ((PLIC_IRQS >> 5) + 1)
+#define PLIC_EN_SIZE     ((PLIC_IRQS + 31) >> 5)
 
 struct plic_regs_t {
 	uint32_t threshold_prio;
@@ -148,10 +148,19 @@ static void plic_irq_handler(const void *arg)
 	save_irq = irq;
 
 	/*
+	 * On Telink retention targets, the CPU can occasionally take a machine
+	 * external interrupt while PLIC claim/complete returns 0. In this case
+	 * there is no pending PLIC source to service or complete, so ignore it.
+	 */
+	if (irq == 0U) {
+		return;
+	}
+
+	/*
 	 * If the IRQ is out of range, call z_irq_spurious.
 	 * A call to z_irq_spurious will not return.
 	 */
-	if (irq == 0U || irq >= PLIC_IRQS)
+	if (irq >= PLIC_IRQS)
 		z_irq_spurious(NULL);
 
 	irq += CONFIG_2ND_LVL_ISR_TBL_OFFSET;
@@ -188,7 +197,8 @@ static int plic_init(void)
 	}
 
 	/* Set priority of each interrupt line to 0 initially */
-	for (i = 0; i < PLIC_IRQS; i++) {
+	prio++; /* no zero ISR, it's reserved for PLIC features */
+	for (i = 1; i < PLIC_IRQS; i++) {
 		*prio = 0U;
 		prio++;
 	}

--- a/drivers/pinctrl/pinctrl_tlx.c
+++ b/drivers/pinctrl/pinctrl_tlx.c
@@ -140,7 +140,7 @@ static inline void pinctrl_tlx_gpio_function_disable(uint32_t pin)
 	reg_gpio_en(pin) &= ~bit;
 }
 
-/* Get pull up (and function for B91) value bits start position (offset) */
+/* Get pull up (and function) value bits start position (offset) */
 static inline int pinctrl_tlx_get_offset(uint32_t pin, uint8_t *offset)
 {
 	switch (TLX_PINMUX_GET_PIN_ID(pin)) {

--- a/dts/bindings/interrupt-controller/telink,plic.yaml
+++ b/dts/bindings/interrupt-controller/telink,plic.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2018, SiFive Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Telink RISCV-V platform-local interrupt controller
+
+compatible: "telink,plic"
+
+include: riscv,plic0.yaml
+
+properties:
+  riscv,ndev:
+    type: int
+    description: Number of external interrupts supported
+    required: true

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -129,7 +129,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_b92.dtsi
+++ b/dts/riscv/telink/telink_b92.dtsi
@@ -139,7 +139,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl321x.dtsi
+++ b/dts/riscv/telink/telink_tl321x.dtsi
@@ -139,7 +139,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl721x.dtsi
+++ b/dts/riscv/telink/telink_tl721x.dtsi
@@ -149,7 +149,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_w91.dtsi
+++ b/dts/riscv/telink/telink_w91.dtsi
@@ -98,7 +98,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/soc/riscv/riscv-privilege/telink_tlx/idle.c
+++ b/soc/riscv/riscv-privilege/telink_tlx/idle.c
@@ -21,7 +21,7 @@ static ALWAYS_INLINE void riscv_idle(unsigned int key)
 	/* unlock interrupts */
 	irq_unlock(key);
 
-	/* Due to silicon bug in B92 platform, the WFI emulation is implemented */
+	/* Due to silicon bug, the WFI emulation is implemented */
 	while (__irq_pending) {
 	}
 }
@@ -58,7 +58,7 @@ void arch_cpu_atomic_idle(unsigned int key)
 }
 
 /**
- * @brief Telink B92 SOC handle IRQ implementation
+ * @brief Telink SOC handle IRQ implementation
  *
  * - __soc_handle_irq: handle SoC-specific details for a pending IRQ
  *   (e.g. clear a pending bit in a SoC-specific register)

--- a/soc/riscv/riscv-privilege/telink_tlx/pinctrl_soc.h
+++ b/soc/riscv/riscv-privilege/telink_tlx/pinctrl_soc.h
@@ -16,7 +16,7 @@
 #endif
 
 /**
- * @brief Telink B9X-series pin type.
+ * @brief Telink TLX-series pin type.
  */
 typedef uint32_t pinctrl_soc_pin_t;
 

--- a/soc/riscv/riscv-privilege/telink_tlx/soc_context.h
+++ b/soc/riscv/riscv-privilege/telink_tlx/soc_context.h
@@ -9,7 +9,7 @@
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 
-/* Telink B91 specific registers. */
+/* Telink specific registers. */
 #if defined(CONFIG_TELINK_TLX_PFT) && defined(CONFIG_ANDES_HWDSP)
 
 	#define SOC_ESF_MEMBERS     \


### PR DESCRIPTION
Adds Telink PLIC interrupt controller support for TLX SoCs.

Changes:
- add Telink PLIC driver, Kconfig and build integration
- revert previous nested interrupt / deep-sleep PLIC workaround
- handle zero PLIC claim on retention targets
- fix TLX naming typos in related Telink code