### PR TITLE
soc: telink: add PLIC interrupt controller support

### DIFF
--- a/drivers/bluetooth/hci/hci_tlx.c
+++ b/drivers/bluetooth/hci/hci_tlx.c
@@ -200,11 +200,7 @@ static int hci_tlx_open(const struct device *dev, bt_hci_recv_t recv)
 	hci_recv = recv;
 	tlx_bt_host_callback_register(&vhci_host_cb);
 
-#if CONFIG_SOC_RISCV_TELINK_B91
-	LOG_DBG("B91 BT started");
-#elif CONFIG_SOC_RISCV_TELINK_B92
-	LOG_DBG("B92 BT started");
-#endif
+	LOG_DBG("TLX BT started");
 
 	return 0;
 }

--- a/drivers/entropy/entropy_tlx_trng.c
+++ b/drivers/entropy/entropy_tlx_trng.c
@@ -12,7 +12,7 @@
 
 
 /* API implementation: driver initialization */
-static int entropy_b9x_trng_init(const struct device *dev)
+static int entropy_tlx_trng_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
@@ -22,7 +22,7 @@ static int entropy_b9x_trng_init(const struct device *dev)
 }
 
 /* API implementation: get_entropy */
-static int entropy_b9x_trng_get_entropy(const struct device *dev,
+static int entropy_tlx_trng_get_entropy(const struct device *dev,
 					uint8_t *buffer, uint16_t length)
 {
 	ARG_UNUSED(dev);
@@ -46,26 +46,26 @@ static int entropy_b9x_trng_get_entropy(const struct device *dev,
 }
 
 /* API implementation: get_entropy_isr */
-static int entropy_b9x_trng_get_entropy_isr(const struct device *dev,
+static int entropy_tlx_trng_get_entropy_isr(const struct device *dev,
 					    uint8_t *buffer, uint16_t length,
 					    uint32_t flags)
 {
 	ARG_UNUSED(flags);
 
 	/* No specific handling in case of running from ISR, just call standard API */
-	entropy_b9x_trng_get_entropy(dev, buffer, length);
+	entropy_tlx_trng_get_entropy(dev, buffer, length);
 
 	return 0;
 }
 
 /* Entropy driver APIs structure */
 static const struct entropy_driver_api entropy_tlx_trng_api = {
-	.get_entropy = entropy_b9x_trng_get_entropy,
-	.get_entropy_isr = entropy_b9x_trng_get_entropy_isr
+	.get_entropy = entropy_tlx_trng_get_entropy,
+	.get_entropy_isr = entropy_tlx_trng_get_entropy_isr
 };
 
 /* Entropy driver registration */
-DEVICE_DT_INST_DEFINE(0, entropy_b9x_trng_init,
+DEVICE_DT_INST_DEFINE(0, entropy_tlx_trng_init,
 		      NULL, NULL, NULL,
 		      PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		      &entropy_tlx_trng_api);

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -45,6 +45,7 @@ zephyr_library_sources_ifdef(CONFIG_RENESAS_RZ_EXT_IRQ      intc_renesas_rz_ext_
 zephyr_library_sources_ifdef(CONFIG_NXP_IRQSTEER            intc_nxp_irqsteer.c)
 zephyr_library_sources_ifdef(CONFIG_INTC_MTK_ADSP           intc_mtk_adsp.c)
 zephyr_library_sources_ifdef(CONFIG_WCH_PFIC                intc_wch_pfic.c)
+zephyr_library_sources_ifdef(CONFIG_PLIC_TELINK             intc_telink_plic.c)
 
 if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -112,4 +112,6 @@ source "drivers/interrupt_controller/Kconfig.mtk_adsp"
 
 source "drivers/interrupt_controller/Kconfig.wch_pfic"
 
+source "drivers/interrupt_controller/Kconfig.telink"
+
 endmenu

--- a/drivers/interrupt_controller/Kconfig.telink
+++ b/drivers/interrupt_controller/Kconfig.telink
@@ -1,0 +1,93 @@
+# Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config PLIC_TELINK
+	bool "Telink Interrupt Controller (PLIC)"
+	default y
+	depends on DT_HAS_TELINK_PLIC_ENABLED
+	select MULTI_LEVEL_INTERRUPTS
+	select 2ND_LEVEL_INTERRUPTS
+	help
+	  Platform Level Interrupt Controller provides support
+	  for external interrupt lines defined by the RISC-V SoC.
+
+if PLIC
+
+config PLIC_SUPPORTS_SOFT_INTERRUPT
+	bool
+	default y
+	depends on DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Enabled when the PLIC supports software-triggered interrupts.
+
+config PLIC_SUPPORTS_TRIG_TYPE
+	bool
+	default y
+	depends on DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Enabled when the PLIC supports multiple trigger types,
+	  such as level, edge, etc.
+
+if PLIC_SUPPORTS_TRIG_TYPE
+
+config PLIC_TRIG_TYPE_REG_OFFSET
+	hex "Trigger type register offset"
+	default 0x1080 if DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Offset to the 'trigger type' register.
+
+config PLIC_TRIG_TYPE_BITWIDTH
+	int "Trigger type bitwidth"
+	default 1
+	help
+	  Number of bits required to differentiate between the trigger types.
+
+config PLIC_SUPPORTS_TRIG_EDGE
+	bool
+	default y
+	depends on DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Enabled when the PLIC supports edge-triggered interrupt.
+
+endif # PLIC_SUPPORTS_TRIG_TYPE
+
+config PLIC_IRQ_AFFINITY
+	bool "Configure IRQ affinity"
+	depends on SMP
+	depends on MP_MAX_NUM_CPUS > 1
+	help
+	  Enable configuration of IRQ affinity.
+
+config PLIC_IRQ_AFFINITY_MASK
+	hex "Default IRQ affinity mask"
+	depends on PLIC_IRQ_AFFINITY
+	default 0x1
+	help
+	  Default mask for the driver when IRQ affinity is enabled.
+
+config PLIC_SHELL
+	bool "PLIC shell commands"
+	depends on SHELL
+	help
+	  Enable additional shell commands useful for debugging.
+	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(uint16_t)).
+
+if PLIC_SHELL
+
+config PLIC_SHELL_IRQ_COUNT
+	bool "IRQ count shell commands"
+	default y
+	help
+	  Records the number of hits per interrupt line and provide shell commands to access them.
+	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(PLIC_IRQ_COUNT_TYPE)).
+
+config PLIC_SHELL_IRQ_AFFINITY
+	bool "Shell commands to configure IRQ affinity"
+	default y
+	depends on PLIC_IRQ_AFFINITY
+	help
+	  Provide shell commands to configure IRQ affinity in runtime.
+
+endif # PLIC_SHELL
+
+endif # PLIC

--- a/drivers/interrupt_controller/intc_telink_plic.c
+++ b/drivers/interrupt_controller/intc_telink_plic.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT sifive_plic_1_0_0
+#define DT_DRV_COMPAT telink_plic
 
 /**
  * @brief Platform Level Interrupt Controller (PLIC) driver
@@ -132,7 +132,7 @@ static inline uint32_t get_plic_enabled_size(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
-	return local_irq_to_reg_index(config->nr_irqs) + 1;
+	return local_irq_to_reg_index(config->nr_irqs + PLIC_REG_SIZE - 1);
 }
 
 static ALWAYS_INLINE uint32_t get_hart_context(const struct device *dev, uint32_t hartid)
@@ -537,10 +537,19 @@ static void plic_irq_handler(const struct device *dev)
 	save_dev[cpu_id] = dev;
 
 	/*
+	 * On Telink retention targets, the CPU can occasionally take a machine
+	 * external interrupt while PLIC claim/complete returns 0. In this case
+	 * there is no pending PLIC source to service or complete, so ignore it.
+	 */
+	if (local_irq == 0U) {
+		return;
+	}
+
+	/*
 	 * If the IRQ is out of range, call z_irq_spurious.
 	 * A call to z_irq_spurious will not return.
 	 */
-	if ((local_irq == 0U) || (local_irq >= config->nr_irqs)) {
+	if (local_irq >= config->nr_irqs) {
 		z_irq_spurious(NULL);
 	}
 
@@ -602,7 +611,7 @@ static int plic_init(const struct device *dev)
 	}
 
 	/* Set priority of each interrupt line to 0 initially */
-	for (uint32_t i = 0; i < config->nr_irqs; i++) {
+	for (uint32_t i = 1; i < config->nr_irqs; i++) {
 		sys_write32(0U, prio_addr + (i * sizeof(uint32_t)));
 	}
 

--- a/drivers/pinctrl/pinctrl_tlx.c
+++ b/drivers/pinctrl/pinctrl_tlx.c
@@ -140,7 +140,7 @@ static inline void pinctrl_tlx_gpio_function_disable(uint32_t pin)
 	reg_gpio_en(pin) &= ~bit;
 }
 
-/* Get pull up (and function for B91) value bits start position (offset) */
+/* Get pull up (and function) value bits start position (offset) */
 static inline int pinctrl_tlx_get_offset(uint32_t pin, uint8_t *offset)
 {
 	switch (TLX_PINMUX_GET_PIN_ID(pin)) {

--- a/dts/bindings/interrupt-controller/telink,plic.yaml
+++ b/dts/bindings/interrupt-controller/telink,plic.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2018, SiFive Inc.
+# Copyright (c) 2026, Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+description: Telink RISCV-V platform-local interrupt controller
+
+compatible: "telink,plic"
+
+include: riscv,plic0.yaml
+
+properties:
+  riscv,ndev:
+    type: int
+    description: Number of external interrupts supported
+    required: true

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -138,7 +138,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_b92.dtsi
+++ b/dts/riscv/telink/telink_b92.dtsi
@@ -148,7 +148,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl321x.dtsi
+++ b/dts/riscv/telink/telink_tl321x.dtsi
@@ -148,7 +148,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl721x.dtsi
+++ b/dts/riscv/telink/telink_tl721x.dtsi
@@ -158,7 +158,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_w91.dtsi
+++ b/dts/riscv/telink/telink_w91.dtsi
@@ -113,7 +113,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/soc/telink/tlsr/telink_b9x/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_b9x/CMakeLists.txt
@@ -44,11 +44,6 @@ set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 zephyr_cc_option_ifdef(CONFIG_ANDES_CODENSE -mexecit)
 zephyr_ld_option_ifdef(CONFIG_ANDES_CODENSE -Wl,--mexecit)
 
-if(CONFIG_TELINK_B9X_MATTER_RETENTION_LAYOUT)
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0 matter_retention.ld)
-endif()
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x1 ilm.ld)
-
 # Wrap allocator functions
 zephyr_link_libraries(
 	-Wl,--wrap,sys_heap_alloc

--- a/soc/telink/tlsr/telink_tlx/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_tlx/CMakeLists.txt
@@ -57,11 +57,6 @@ set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 zephyr_cc_option_ifdef(CONFIG_ANDES_CODENSE -mexecit)
 zephyr_ld_option_ifdef(CONFIG_ANDES_CODENSE -Wl,--mexecit)
 
-if(CONFIG_TELINK_B9X_MATTER_RETENTION_LAYOUT)
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0 matter_retention.ld)
-endif()
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x1 ilm.ld)
-
 # Wrap allocator functions
 zephyr_link_libraries(
 	-Wl,--wrap,sys_heap_alloc

--- a/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
+++ b/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
@@ -8,14 +8,14 @@
 #include <zephyr/drivers/uart.h>
 #include <bootutil/bootutil_log.h>
 #include <zephyr/sys/crc.h>
-BOOT_LOG_MODULE_REGISTER(telink_b9x_mcuboot);
+BOOT_LOG_MODULE_REGISTER(telink_tlx_mcuboot);
 
-static bool telink_b9x_mcu_boot_startup(void);
+static bool telink_tlx_mcu_boot_startup(void);
 static __maybe_unused void printk_buf(const char *comment, void *buf, size_t buf_len);
 
 void __wrap_main(void)
 {
-	if (telink_b9x_mcu_boot_startup()) {
+	if (telink_tlx_mcu_boot_startup()) {
 		extern void __real_main(void);
 
 		__real_main();
@@ -23,11 +23,11 @@ void __wrap_main(void)
 }
 
 /* Vendor specific code during MCUBoot startup */
-static bool telink_b9x_mcu_boot_startup(void)
+static bool telink_tlx_mcu_boot_startup(void)
 {
 	bool result = true; /* run MCUBoot main */
 
-	BOOT_LOG_INF("telink B9x MCUBoot on early boot");
+	BOOT_LOG_INF("telink TLX MCUBoot on early boot");
 #if CONFIG_SOC_RISCV_TELINK_B92
 	bool show_chip_id = false;
 

--- a/soc/telink/tlsr/telink_tlx/pinctrl_soc.h
+++ b/soc/telink/tlsr/telink_tlx/pinctrl_soc.h
@@ -16,7 +16,7 @@
 #endif
 
 /**
- * @brief Telink B9X-series pin type.
+ * @brief Telink TLX-series pin type.
  */
 typedef uint32_t pinctrl_soc_pin_t;
 

--- a/soc/telink/tlsr/telink_tlx/soc_context.h
+++ b/soc/telink/tlsr/telink_tlx/soc_context.h
@@ -9,7 +9,7 @@
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 
-/* Telink B91 specific registers. */
+/* Telink specific registers. */
 #if defined(CONFIG_TELINK_TLX_PFT) && defined(CONFIG_ANDES_HWDSP)
 
 #define SOC_ESF_MEMBERS                                                                            \

--- a/soc/telink/tlsr/telink_w9x/debug.c
+++ b/soc/telink/tlsr/telink_w9x/debug.c
@@ -89,7 +89,7 @@ static void telink_w91_debug_init(void)
 			IRQ_CONNECT(UART_ISR_NUM + CONFIG_2ND_LVL_ISR_TBL_OFFSET, 0,
 				telink_w91_debug_isr, NULL, 0);
 			riscv_plic_set_priority(IRQ_TO_L2(UART_ISR_NUM) |
-							DT_IRQN(DT_INST(0, sifive_plic_1_0_0)),
+							DT_IRQN(DT_INST(0, telink_plic)),
 						1);
 		}
 		arch_irq_unlock(keys);
@@ -104,10 +104,10 @@ void telink_w91_debug_isr_set(bool enabled, void (*on_rx)(char c, void *ctx), vo
 		telink_w91_debug_isr_data.ctx = ctx;
 		__write_reg32(UART_BASE_ADDR + OFT_ATCUART_IER, (1 << 0));
 		riscv_plic_irq_enable(IRQ_TO_L2(UART_ISR_NUM) |
-				      DT_IRQN(DT_INST(0, sifive_plic_1_0_0)));
+				      DT_IRQN(DT_INST(0, telink_plic)));
 	} else {
 		riscv_plic_irq_disable(IRQ_TO_L2(UART_ISR_NUM) |
-				       DT_IRQN(DT_INST(0, sifive_plic_1_0_0)));
+				       DT_IRQN(DT_INST(0, telink_plic)));
 		__write_reg32(UART_BASE_ADDR + OFT_ATCUART_IER, 0);
 		telink_w91_debug_isr_data.on_rx = NULL;
 		telink_w91_debug_isr_data.ctx = NULL;


### PR DESCRIPTION
Adds Telink PLIC interrupt controller support for TLX SoCs.

Changes:
- add Telink PLIC driver, Kconfig and build integration
- revert previous nested interrupt / deep-sleep PLIC workaround
- handle zero PLIC claim on retention targets
- fix TLX naming typos in related Telink code