### PR TITLE
drivers: pinctrl: telink_x: Fix peripherals input pins

### DIFF
--- a/drivers/pinctrl/pinctrl_b9x.c
+++ b/drivers/pinctrl/pinctrl_b9x.c
@@ -5,6 +5,9 @@
  */
 
 #include "analog.h"
+#if CONFIG_PM
+#include "gpio.h"
+#endif
 #include <zephyr/drivers/pinctrl.h>
 #if CONFIG_SOC_RISCV_TELINK_B91
 #include <zephyr/dt-bindings/pinctrl/b91-pinctrl.h>
@@ -221,7 +224,9 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 
 	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
 	pinctrl_b9x_gpio_function_disable(pin);
-
+#if CONFIG_PM
+	gpio_input_en(pin);
+#endif
 	/* set pull value */
 	pull = pull << offset;
 	analog_write_reg8(pull_up_en_addr, (analog_read_reg8(pull_up_en_addr) & mask) | pull);

--- a/drivers/pinctrl/pinctrl_tlx.c
+++ b/drivers/pinctrl/pinctrl_tlx.c
@@ -5,6 +5,9 @@
  */
 
 #include "analog.h"
+#if CONFIG_PM
+#include "gpio.h"
+#endif
 #include <zephyr/drivers/pinctrl.h>
 #if CONFIG_SOC_RISCV_TELINK_TL321X
 #include <zephyr/dt-bindings/pinctrl/tl321x-pinctrl.h>
@@ -206,7 +209,9 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 
 	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
 	pinctrl_tlx_gpio_function_disable(pin);
-
+#if CONFIG_PM
+	gpio_input_en(pin);
+#endif
 	/* set pull value */
 	pull = pull << offset;
 	analog_write_reg8(pull_up_en_addr, (analog_read_reg8(pull_up_en_addr) & mask) | pull);


### PR DESCRIPTION
Fixed peripherals input pins when power managements is enabled. When power management is enabled all pins input buffers are disabled, when peripheral is connected this buffer should be enabled back to provide input peripheral functionality.