### PR TITLE
telink: tl3238x: fix UART tx/rx anomalies after deep retention

### DIFF
--- a/soc/telink/tlsr/telink_tlx/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_tlx/CMakeLists.txt
@@ -69,11 +69,6 @@ set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 zephyr_cc_option_ifdef(CONFIG_ANDES_CODENSE -mexecit)
 zephyr_ld_option_ifdef(CONFIG_ANDES_CODENSE -Wl,--mexecit)
 
-if(CONFIG_TELINK_B9X_MATTER_RETENTION_LAYOUT)
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0 matter_retention.ld)
-endif()
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x1 ilm.ld)
-
 # Wrap allocator functions
 zephyr_link_libraries(
 	-Wl,--wrap,sys_heap_alloc

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -207,7 +207,7 @@ __attribute__((noinline)) __attribute__((section(".ram_code"))) __attribute__((o
 void gen_fsk_close_unused_clock(void)
 {
 	RST_BIT_CLR(reg_rst0, FLD_RST0_I2C0);
-    RST_BIT_CLR(reg_rst0, FLD_RST0_UART1);
+    // RST_BIT_CLR(reg_rst0, FLD_RST0_UART1);
     
     RST_BIT_CLR(reg_rst1, FLD_RST1_UART3);
     RST_BIT_CLR(reg_rst1, FLD_RST1_GSPI);
@@ -232,7 +232,7 @@ void gen_fsk_close_unused_clock(void)
 
 	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_LSPI_EN);
 	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_I2C0_EN);
-	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_UART1_EN);
+	// CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_UART1_EN);
 
 	CLOCK_BIT_CLR(reg_clk_en1, FLD_CLK0_UART3_EN);
 	CLOCK_BIT_CLR(reg_clk_en1, FLD_CLK1_DMA_EN);


### PR DESCRIPTION
 - Stop operating the uart clock reg in gen_fsk_close_unused_clock .
 - Delete an unnecessary configurations, and this was an incidental act .

@damien0x0023 @haiwentelink This has been handled simply for now . The configuration for operating via devicetree control registers will be merged into tl_develop_v4.1.0 later .