### PR TITLE
Update BLE/PM/OTA and add PLIC suport for tl323x

### DIFF
--- a/.github/workflows/telink-tl322x-build.yaml
+++ b/.github/workflows/telink-tl322x-build.yaml
@@ -43,7 +43,7 @@ jobs:
       run: |
         cd ../modules/hal/telink/hal_v2
         chmod +x fetch_sdk.sh
-        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git f50d422d780efb73af939650ef7b8c6bf5a0b99b
+        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git 6a922387a99de678cfb35d17d0742a3040603686
 
     - name: Build TL322x samples/basic/blinky
       run: |

--- a/.github/workflows/telink-tl322x-nds-build.yaml
+++ b/.github/workflows/telink-tl322x-nds-build.yaml
@@ -46,7 +46,7 @@ jobs:
       run: |
         cd ../modules/hal/telink/hal_v2
         chmod +x fetch_sdk.sh
-        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git f50d422d780efb73af939650ef7b8c6bf5a0b99b
+        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git 6a922387a99de678cfb35d17d0742a3040603686
 
     - name: Build TL322x samples/basic/blinky
       run: |

--- a/.github/workflows/telink-tl323x-build.yaml
+++ b/.github/workflows/telink-tl323x-build.yaml
@@ -43,7 +43,7 @@ jobs:
       run: |
         cd ../modules/hal/telink/hal_v2
         chmod +x fetch_sdk.sh
-        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git f50d422d780efb73af939650ef7b8c6bf5a0b99b
+        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git 6a922387a99de678cfb35d17d0742a3040603686
 
     - name: Download and extract TL323X firmware binaries
       run: |

--- a/.github/workflows/telink-tl323x-nds-build.yaml
+++ b/.github/workflows/telink-tl323x-nds-build.yaml
@@ -46,7 +46,7 @@ jobs:
       run: |
         cd ../modules/hal/telink/hal_v2
         chmod +x fetch_sdk.sh
-        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git f50d422d780efb73af939650ef7b8c6bf5a0b99b
+        ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git 6a922387a99de678cfb35d17d0742a3040603686
 
     - name: Download and extract TL323X firmware binaries
       run: |

--- a/drivers/bluetooth/hci/hci_tlx.c
+++ b/drivers/bluetooth/hci/hci_tlx.c
@@ -199,7 +199,8 @@ static int hci_tlx_open(const struct device *dev, bt_hci_recv_t recv)
 	hci_dev = dev;
 	hci_recv = recv;
 	tlx_bt_host_callback_register(&vhci_host_cb);
-	LOG_DBG("TLNK BT started");
+
+	LOG_DBG("TLX BT started");
 
 	return 0;
 }

--- a/drivers/entropy/entropy_tlx_trng.c
+++ b/drivers/entropy/entropy_tlx_trng.c
@@ -21,7 +21,8 @@ static int entropy_tlx_trng_init(const struct device *dev)
 }
 
 /* API implementation: get_entropy */
-static int entropy_tlx_trng_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
+static int entropy_tlx_trng_get_entropy(const struct device *dev,
+					uint8_t *buffer, uint16_t length)
 {
 	ARG_UNUSED(dev);
 
@@ -44,8 +45,9 @@ static int entropy_tlx_trng_get_entropy(const struct device *dev, uint8_t *buffe
 }
 
 /* API implementation: get_entropy_isr */
-static int entropy_tlx_trng_get_entropy_isr(const struct device *dev, uint8_t *buffer,
-					    uint16_t length, uint32_t flags)
+static int entropy_tlx_trng_get_entropy_isr(const struct device *dev,
+					    uint8_t *buffer, uint16_t length,
+					    uint32_t flags)
 {
 	ARG_UNUSED(flags);
 
@@ -58,8 +60,11 @@ static int entropy_tlx_trng_get_entropy_isr(const struct device *dev, uint8_t *b
 /* Entropy driver APIs structure */
 static const struct entropy_driver_api entropy_tlx_trng_api = {
 	.get_entropy = entropy_tlx_trng_get_entropy,
-	.get_entropy_isr = entropy_tlx_trng_get_entropy_isr};
+	.get_entropy_isr = entropy_tlx_trng_get_entropy_isr
+};
 
 /* Entropy driver registration */
-DEVICE_DT_INST_DEFINE(0, entropy_tlx_trng_init, NULL, NULL, NULL, PRE_KERNEL_1,
-		      CONFIG_ENTROPY_INIT_PRIORITY, &entropy_tlx_trng_api);
+DEVICE_DT_INST_DEFINE(0, entropy_tlx_trng_init,
+		      NULL, NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
+		      &entropy_tlx_trng_api);

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -45,6 +45,7 @@ zephyr_library_sources_ifdef(CONFIG_RENESAS_RZ_EXT_IRQ      intc_renesas_rz_ext_
 zephyr_library_sources_ifdef(CONFIG_NXP_IRQSTEER            intc_nxp_irqsteer.c)
 zephyr_library_sources_ifdef(CONFIG_INTC_MTK_ADSP           intc_mtk_adsp.c)
 zephyr_library_sources_ifdef(CONFIG_WCH_PFIC                intc_wch_pfic.c)
+zephyr_library_sources_ifdef(CONFIG_PLIC_TELINK             intc_telink_plic.c)
 
 if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -112,4 +112,6 @@ source "drivers/interrupt_controller/Kconfig.mtk_adsp"
 
 source "drivers/interrupt_controller/Kconfig.wch_pfic"
 
+source "drivers/interrupt_controller/Kconfig.telink"
+
 endmenu

--- a/drivers/interrupt_controller/Kconfig.telink
+++ b/drivers/interrupt_controller/Kconfig.telink
@@ -1,0 +1,93 @@
+# Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config PLIC_TELINK
+	bool "Telink Interrupt Controller (PLIC)"
+	default y
+	depends on DT_HAS_TELINK_PLIC_ENABLED
+	select MULTI_LEVEL_INTERRUPTS
+	select 2ND_LEVEL_INTERRUPTS
+	help
+	  Platform Level Interrupt Controller provides support
+	  for external interrupt lines defined by the RISC-V SoC.
+
+if PLIC
+
+config PLIC_SUPPORTS_SOFT_INTERRUPT
+	bool
+	default y
+	depends on DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Enabled when the PLIC supports software-triggered interrupts.
+
+config PLIC_SUPPORTS_TRIG_TYPE
+	bool
+	default y
+	depends on DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Enabled when the PLIC supports multiple trigger types,
+	  such as level, edge, etc.
+
+if PLIC_SUPPORTS_TRIG_TYPE
+
+config PLIC_TRIG_TYPE_REG_OFFSET
+	hex "Trigger type register offset"
+	default 0x1080 if DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Offset to the 'trigger type' register.
+
+config PLIC_TRIG_TYPE_BITWIDTH
+	int "Trigger type bitwidth"
+	default 1
+	help
+	  Number of bits required to differentiate between the trigger types.
+
+config PLIC_SUPPORTS_TRIG_EDGE
+	bool
+	default y
+	depends on DT_HAS_ANDESTECH_NCEPLIC100_ENABLED
+	help
+	  Enabled when the PLIC supports edge-triggered interrupt.
+
+endif # PLIC_SUPPORTS_TRIG_TYPE
+
+config PLIC_IRQ_AFFINITY
+	bool "Configure IRQ affinity"
+	depends on SMP
+	depends on MP_MAX_NUM_CPUS > 1
+	help
+	  Enable configuration of IRQ affinity.
+
+config PLIC_IRQ_AFFINITY_MASK
+	hex "Default IRQ affinity mask"
+	depends on PLIC_IRQ_AFFINITY
+	default 0x1
+	help
+	  Default mask for the driver when IRQ affinity is enabled.
+
+config PLIC_SHELL
+	bool "PLIC shell commands"
+	depends on SHELL
+	help
+	  Enable additional shell commands useful for debugging.
+	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(uint16_t)).
+
+if PLIC_SHELL
+
+config PLIC_SHELL_IRQ_COUNT
+	bool "IRQ count shell commands"
+	default y
+	help
+	  Records the number of hits per interrupt line and provide shell commands to access them.
+	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(PLIC_IRQ_COUNT_TYPE)).
+
+config PLIC_SHELL_IRQ_AFFINITY
+	bool "Shell commands to configure IRQ affinity"
+	default y
+	depends on PLIC_IRQ_AFFINITY
+	help
+	  Provide shell commands to configure IRQ affinity in runtime.
+
+endif # PLIC_SHELL
+
+endif # PLIC

--- a/drivers/interrupt_controller/intc_telink_plic.c
+++ b/drivers/interrupt_controller/intc_telink_plic.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT sifive_plic_1_0_0
+#define DT_DRV_COMPAT telink_plic
 
 /**
  * @brief Platform Level Interrupt Controller (PLIC) driver
@@ -28,17 +28,17 @@
 #include <zephyr/drivers/interrupt_controller/riscv_plic.h>
 #include <zephyr/irq.h>
 
-#define PLIC_BASE_ADDR(n)    DT_INST_REG_ADDR(n)
+#define PLIC_BASE_ADDR(n) DT_INST_REG_ADDR(n)
 /*
  * These registers' offset are defined in the RISCV PLIC specs, see:
  * https://github.com/riscv/riscv-plic-spec
  */
-#define CONTEXT_BASE         0x200000
-#define CONTEXT_SIZE         0x1000
-#define CONTEXT_THRESHOLD    0x00
-#define CONTEXT_CLAIM        0x04
-#define CONTEXT_ENABLE_BASE  0x2000
-#define CONTEXT_ENABLE_SIZE  0x80
+#define CONTEXT_BASE 0x200000
+#define CONTEXT_SIZE 0x1000
+#define CONTEXT_THRESHOLD 0x00
+#define CONTEXT_CLAIM 0x04
+#define CONTEXT_ENABLE_BASE 0x2000
+#define CONTEXT_ENABLE_SIZE 0x80
 #define CONTEXT_PENDING_BASE 0x1000
 
 /*
@@ -59,7 +59,7 @@
 #define INTC_PLIC_STATIC
 #define INTC_PLIC_STATIC_INLINE
 #else
-#define INTC_PLIC_STATIC        static
+#define INTC_PLIC_STATIC static
 #define INTC_PLIC_STATIC_INLINE static inline
 #endif /* CONFIG_TEST_INTC_PLIC */
 
@@ -112,6 +112,7 @@ struct plic_data {
 #ifdef CONFIG_PLIC_IRQ_AFFINITY
 	plic_cpumask_t *irq_cpumask;
 #endif /* CONFIG_PLIC_IRQ_AFFINITY */
+
 };
 
 static uint32_t save_irq[CONFIG_MP_MAX_NUM_CPUS];
@@ -131,7 +132,7 @@ static inline uint32_t get_plic_enabled_size(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
-	return local_irq_to_reg_index(config->nr_irqs) + 1;
+	return local_irq_to_reg_index(config->nr_irqs + PLIC_REG_SIZE - 1);
 }
 
 static ALWAYS_INLINE uint32_t get_hart_context(const struct device *dev, uint32_t hartid)
@@ -500,13 +501,6 @@ static void plic_irq_handler(const struct device *dev)
 	uint32_t cpu_id = arch_curr_cpu()->id;
 	/* Get the IRQ number generating the interrupt */
 	const uint32_t local_irq = sys_read32(claim_complete_addr);
-#if (CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION || CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION)
-	if (!local_irq) {
-		extern void telink_zero_isr(void);
-		telink_zero_isr();
-		return;
-	}
-#endif
 
 #ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 	uint16_t *cpu_count = get_irq_hit_count_cpu(dev, cpu_id, local_irq);
@@ -543,10 +537,19 @@ static void plic_irq_handler(const struct device *dev)
 	save_dev[cpu_id] = dev;
 
 	/*
+	 * On Telink retention targets, the CPU can occasionally take a machine
+	 * external interrupt while PLIC claim/complete returns 0. In this case
+	 * there is no pending PLIC source to service or complete, so ignore it.
+	 */
+	if (local_irq == 0U) {
+		return;
+	}
+
+	/*
 	 * If the IRQ is out of range, call z_irq_spurious.
 	 * A call to z_irq_spurious will not return.
 	 */
-	if ((local_irq == 0U) || (local_irq >= config->nr_irqs)) {
+	if (local_irq >= config->nr_irqs) {
 		z_irq_spurious(NULL);
 	}
 
@@ -608,7 +611,7 @@ static int plic_init(const struct device *dev)
 	}
 
 	/* Set priority of each interrupt line to 0 initially */
-	for (uint32_t i = 0; i < config->nr_irqs; i++) {
+	for (uint32_t i = 1; i < config->nr_irqs; i++) {
 		sys_write32(0U, prio_addr + (i * sizeof(uint32_t)));
 	}
 
@@ -715,7 +718,7 @@ static int cmd_stats_clear(const struct shell *sh, size_t argc, char *argv[])
 	       config->nr_irqs *
 		       COND_CODE_1(CONFIG_MP_MAX_NUM_CPUS, (1),
 				   (UTIL_INC(CONFIG_MP_MAX_NUM_CPUS))) *
-							   sizeof(uint16_t));
+		       sizeof(uint16_t));
 
 	shell_print(sh, "Cleared stats of %s.\n", dev->name);
 
@@ -824,20 +827,20 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 #ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 SHELL_STATIC_SUBCMD_SET_CREATE(plic_stats_cmds,
-			       SHELL_CMD_ARG(get, &dsub_device_name,
-					     "Read PLIC's stats.\n"
-					     "Usage: plic stats get <device> [minimum hits]",
-					     cmd_stats_get, 2, 1),
-			       SHELL_CMD_ARG(clear, &dsub_device_name,
-					     "Reset PLIC's stats.\n"
-					     "Usage: plic stats clear <device>",
-					     cmd_stats_clear, 2, 0),
-			       SHELL_SUBCMD_SET_END);
+	SHELL_CMD_ARG(get, &dsub_device_name,
+		"Read PLIC's stats.\n"
+		"Usage: plic stats get <device> [minimum hits]",
+		cmd_stats_get, 2, 1),
+	SHELL_CMD_ARG(clear, &dsub_device_name,
+		"Reset PLIC's stats.\n"
+		"Usage: plic stats clear <device>",
+		cmd_stats_clear, 2, 0),
+	SHELL_SUBCMD_SET_END
+);
 #endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
 
 #ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
-SHELL_STATIC_SUBCMD_SET_CREATE(
-	plic_affinity_cmds,
+SHELL_STATIC_SUBCMD_SET_CREATE(plic_affinity_cmds,
 	SHELL_CMD_ARG(set, &dsub_device_name,
 		      "Set IRQ affinity.\n"
 		      "Usage: plic affinity set <device> <local_irq> <cpumask>",
@@ -851,12 +854,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 
 SHELL_STATIC_SUBCMD_SET_CREATE(plic_cmds,
 #ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
-			       SHELL_CMD(stats, &plic_stats_cmds, "IRQ stats", NULL),
+	SHELL_CMD(stats, &plic_stats_cmds, "IRQ stats", NULL),
 #endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
 #ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
-			       SHELL_CMD(affinity, &plic_affinity_cmds, "IRQ affinity", NULL),
+	SHELL_CMD(affinity, &plic_affinity_cmds, "IRQ affinity", NULL),
 #endif /* CONFIG_PLIC_SHELL_IRQ_AFFINITY */
-			       SHELL_SUBCMD_SET_END);
+	SHELL_SUBCMD_SET_END
+);
 
 SHELL_CMD_REGISTER(plic, &plic_cmds, "PLIC shell commands", NULL);
 #endif /* CONFIG_PLIC_SHELL */
@@ -866,8 +870,8 @@ SHELL_CMD_REGISTER(plic, &plic_cmds, "PLIC shell commands", NULL);
 #ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 #define PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n)                                                          \
 	static uint16_t local_irq_count_##n[COND_CODE_1(CONFIG_MP_MAX_NUM_CPUS, (1),               \
-							(UTIL_INC(CONFIG_MP_MAX_NUM_CPUS)))]   \
-								[PLIC_MIN_IRQ_NUM(n)];
+							(UTIL_INC(CONFIG_MP_MAX_NUM_CPUS)))]       \
+					   [PLIC_MIN_IRQ_NUM(n)];
 #define PLIC_INTC_IRQ_COUNT_INIT(n)                                                                \
 	.stats = {                                                                                 \
 		.irq_count = &local_irq_count_##n[0][0],                                           \
@@ -892,8 +896,10 @@ SHELL_CMD_REGISTER(plic, &plic_cmds, "PLIC shell commands", NULL);
 #define PLIC_INTC_DATA_INIT(n)                                                                     \
 	PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n);                                                         \
 	PLIC_IRQ_CPUMASK_BUF_DECLARE(n);                                                           \
-	static struct plic_data plic_data_##n = {PLIC_INTC_IRQ_COUNT_INIT(n)                       \
-							 PLIC_IRQ_CPUMASK_BUF_INIT(n)};
+	static struct plic_data plic_data_##n = {                                                  \
+		PLIC_INTC_IRQ_COUNT_INIT(n)                                                        \
+		PLIC_IRQ_CPUMASK_BUF_INIT(n)                                                       \
+	};
 
 #define PLIC_INTC_IRQ_FUNC_DECLARE(n) static void plic_irq_config_func_##n(void)
 
@@ -931,12 +937,15 @@ SHELL_CMD_REGISTER(plic, &plic_cmds, "PLIC shell commands", NULL);
 	PLIC_INTC_IRQ_FUNC_DEFINE(n)
 
 #define PLIC_INTC_DEVICE_INIT(n)                                                                   \
-	IRQ_PARENT_ENTRY_DEFINE(plic##n, DEVICE_DT_INST_GET(n), DT_INST_IRQN(n),                   \
-				INTC_INST_ISR_TBL_OFFSET(n),                                       \
-				DT_INST_INTC_GET_AGGREGATOR_LEVEL(n));                             \
+	IRQ_PARENT_ENTRY_DEFINE(                                                                   \
+		plic##n, DEVICE_DT_INST_GET(n), DT_INST_IRQN(n),                                   \
+		INTC_INST_ISR_TBL_OFFSET(n),                                                       \
+		DT_INST_INTC_GET_AGGREGATOR_LEVEL(n));                                             \
 	PLIC_INTC_CONFIG_INIT(n)                                                                   \
 	PLIC_INTC_DATA_INIT(n)                                                                     \
-	DEVICE_DT_INST_DEFINE(n, &plic_init, NULL, &plic_data_##n, &plic_config_##n, PRE_KERNEL_1, \
-			      CONFIG_INTC_INIT_PRIORITY, NULL);
+	DEVICE_DT_INST_DEFINE(n, &plic_init, NULL,                                                 \
+			      &plic_data_##n, &plic_config_##n,                                    \
+			      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,                             \
+			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(PLIC_INTC_DEVICE_INIT)

--- a/drivers/pinctrl/pinctrl_b9x.c
+++ b/drivers/pinctrl/pinctrl_b9x.c
@@ -5,6 +5,7 @@
  */
 
 #include "analog.h"
+#include "gpio.h"
 #include <zephyr/drivers/pinctrl.h>
 #if CONFIG_SOC_RISCV_TELINK_B91
 #include <zephyr/dt-bindings/pinctrl/b91-pinctrl.h>
@@ -221,6 +222,9 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 
 	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
 	pinctrl_b9x_gpio_function_disable(pin);
+
+	/* set input enable */
+	gpio_input_en(pin);
 
 	/* set pull value */
 	pull = pull << offset;

--- a/drivers/pinctrl/pinctrl_tlx.c
+++ b/drivers/pinctrl/pinctrl_tlx.c
@@ -151,7 +151,7 @@ static inline void pinctrl_tlx_gpio_function_disable(uint32_t pin)
 	reg_gpio_en(pin) &= ~bit;
 }
 
-/* Get pull up (and function for B91) value bits start position (offset) */
+/* Get pull up (and function) value bits start position (offset) */
 static inline int pinctrl_tlx_get_offset(uint32_t pin, uint8_t *offset)
 {
 	switch (TLX_PINMUX_GET_PIN_ID(pin)) {

--- a/drivers/pinctrl/pinctrl_tlx.c
+++ b/drivers/pinctrl/pinctrl_tlx.c
@@ -198,9 +198,6 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 	uint32_t pin = TLX_PINMUX_GET_PIN(*pinctrl);
 	uint8_t pull_up_en_addr = reg_pull_up_en(pin);
 
-	/* set input enable */
-	gpio_input_en(pin);
-
 	/* calculate offset and mask for the func and pull values */
 	status = pinctrl_tlx_get_offset(pin, &offset);
 	if (status != 0) {
@@ -224,8 +221,11 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 		(reg_pin_mux(pin) & (~TL323X_PIN_FUNC_POS)) | (func & TL323X_PIN_FUNC_POS);
 #endif
 
-	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
+	/* disable GPIO function (can be enabled back by GPIO driver) */
 	pinctrl_tlx_gpio_function_disable(pin);
+
+	/* set input enable */
+	gpio_input_en(pin);
 
 	/* set pull value */
 	pull = pull << offset;

--- a/dts/bindings/interrupt-controller/telink,plic.yaml
+++ b/dts/bindings/interrupt-controller/telink,plic.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2018, SiFive Inc.
+# Copyright (c) 2026, Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+description: Telink RISCV-V platform-local interrupt controller
+
+compatible: "telink,plic"
+
+include: riscv,plic0.yaml
+
+properties:
+  riscv,ndev:
+    type: int
+    description: Number of external interrupts supported
+    required: true

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -138,7 +138,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_b92.dtsi
+++ b/dts/riscv/telink/telink_b92.dtsi
@@ -148,7 +148,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl321x.dtsi
+++ b/dts/riscv/telink/telink_tl321x.dtsi
@@ -148,7 +148,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl322x.dtsi
+++ b/dts/riscv/telink/telink_tl322x.dtsi
@@ -187,7 +187,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl323x.dtsi
+++ b/dts/riscv/telink/telink_tl323x.dtsi
@@ -148,7 +148,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl523x.dtsi
+++ b/dts/riscv/telink/telink_tl523x.dtsi
@@ -133,7 +133,7 @@
 		};
 
 		plic0: interrupt-controller@860000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_tl721x.dtsi
+++ b/dts/riscv/telink/telink_tl721x.dtsi
@@ -158,7 +158,7 @@
 		};
 
 		plic0: interrupt-controller@c4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/dts/riscv/telink/telink_w91.dtsi
+++ b/dts/riscv/telink/telink_w91.dtsi
@@ -113,7 +113,7 @@
 		};
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "telink,plic";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;

--- a/soc/telink/tlsr/telink_b9x/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_b9x/CMakeLists.txt
@@ -48,11 +48,6 @@ set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 zephyr_cc_option_ifdef(CONFIG_ANDES_CODENSE -mexecit)
 zephyr_ld_option_ifdef(CONFIG_ANDES_CODENSE -Wl,--mexecit)
 
-if(CONFIG_TELINK_B9X_MATTER_RETENTION_LAYOUT)
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x0 matter_retention.ld)
-endif()
-zephyr_linker_sources(RAM_SECTIONS SORT_KEY 0x1 ilm.ld)
-
 # Wrap allocator functions
 zephyr_link_libraries(
 	-Wl,--wrap,sys_heap_alloc

--- a/soc/telink/tlsr/telink_b9x/soc.c
+++ b/soc/telink/tlsr/telink_b9x/soc.c
@@ -143,9 +143,7 @@ unsigned int cclk = DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency);
 	sys_init(POWER_MODE, VBAT_TYPE, GPIO_VOLTAGE_3V3);
 #endif
 
-#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
-#endif /* CONFIG_PM */
 
 #if (defined(CONFIG_BT_B9X) || defined(CONFIG_IEEE802154))
 	soc_load_rf_parameters_normal();
@@ -213,9 +211,7 @@ void soc_b9x_restore(void)
 	sys_init(POWER_MODE, VBAT_TYPE, GPIO_VOLTAGE_3V3);
 #endif
 
-#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
-#endif /* CONFIG_PM */
 
 #if (defined(CONFIG_BT_B9X) || defined(CONFIG_IEEE802154))
 	soc_load_rf_parameters_deep_retention();

--- a/soc/telink/tlsr/telink_tlx/Kconfig
+++ b/soc/telink/tlsr/telink_tlx/Kconfig
@@ -184,7 +184,7 @@ endif
 
 config MCUBOOT_START_OFFSET
 	hex "Leave space during building MCUBoot"
-	default 0x5000 if SOC_RISCV_TELINK_TL323X && MCUBOOT
+	default 0x5000 if SOC_RISCV_TELINK_TL323X && BOOTLOADER_MCUBOOT
 	default 0x0
 	help
 		The MCUboot offset value.

--- a/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
+++ b/soc/telink/tlsr/telink_tlx/mcu_boot_startup.c
@@ -40,6 +40,9 @@ static bool telink_tlx_mcu_boot_startup(void)
 {
 	bool result = true; /* run MCUBoot main */
 
+	/* please enable log for debug purpose */
+	/* BOOT_LOG_INF("telink TLX MCUBoot on early boot"); */
+
 #if CONFIG_SOC_RISCV_TELINK_TL323X
 	bool show_chip_id = false;
 

--- a/soc/telink/tlsr/telink_tlx/pinctrl_soc.h
+++ b/soc/telink/tlsr/telink_tlx/pinctrl_soc.h
@@ -20,7 +20,7 @@
 #endif
 
 /**
- * @brief Telink B9X-series pin type.
+ * @brief Telink TLX-series pin type.
  */
 typedef uint32_t pinctrl_soc_pin_t;
 

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -199,7 +199,6 @@ void soc_load_rf_parameters_deep_retention(void)
 #endif
 
 #if CONFIG_PM
-#define RST_BIT_SET(x, n)    ((x) |=~(n))
 #define RST_BIT_CLR(x, n)    ((x) &=~(n))
 #define CLOCK_BIT_CLR(x, n)    ((x) &=~(n))
 #if CONFIG_SOC_RISCV_TELINK_TL323X
@@ -207,32 +206,34 @@ __attribute__((noinline)) __attribute__((section(".ram_code"))) __attribute__((o
 void gen_fsk_close_unused_clock(void)
 {
 	RST_BIT_CLR(reg_rst0, FLD_RST0_I2C0);
-	RST_BIT_CLR(reg_rst0, FLD_RST0_UART1);
+	/* comment because some user cases need UART1*/
+    /* RST_BIT_CLR(reg_rst0, FLD_RST0_UART1); */
 
-	RST_BIT_CLR(reg_rst1, FLD_RST1_UART3);
-	RST_BIT_CLR(reg_rst1, FLD_RST1_GSPI);
-	RST_BIT_CLR(reg_rst1, FLD_RST1_DMA);
-	RST_BIT_CLR(reg_rst1, FLD_RST1_SPISLV);
+    RST_BIT_CLR(reg_rst1, FLD_RST1_UART3);
+    RST_BIT_CLR(reg_rst1, FLD_RST1_GSPI);
+    RST_BIT_CLR(reg_rst1, FLD_RST1_DMA);
+    RST_BIT_CLR(reg_rst1, FLD_RST1_SPISLV);
 
-	RST_BIT_CLR(reg_rst2, FLD_RST2_I2C1);
+    RST_BIT_CLR(reg_rst2, FLD_RST2_I2C1);
 	RST_BIT_CLR(reg_rst2, FLD_RST2_TRNG);
 
-	RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC1);
+    RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC1);
 	RST_BIT_CLR(reg_rst3, FLD_RST3_BROM);
-	RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC);
+    RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC);
 
-	RST_BIT_CLR(reg_rst4, FLD_RST4_UART4);
+    RST_BIT_CLR(reg_rst4, FLD_RST4_UART4);
 
-	RST_BIT_CLR(reg_rst5, FLD_RST5_UART2);
-	RST_BIT_CLR(reg_rst5, FLD_RST5_PEM);
+    RST_BIT_CLR(reg_rst5, FLD_RST5_UART2);
+    RST_BIT_CLR(reg_rst5, FLD_RST5_PEM);
 
-	RST_BIT_CLR(reg_rst6, FLD_RST6_RZ);
+    RST_BIT_CLR(reg_rst6, FLD_RST6_RZ);
 
-	RST_BIT_CLR(reg_rst7, FLD_RST7_USB1);
+    RST_BIT_CLR(reg_rst7, FLD_RST7_USB1);
 
 	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_LSPI_EN);
 	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_I2C0_EN);
-	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_UART1_EN);
+	/* comment because some user cases need UART1*/
+	/* CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_UART1_EN); */
 
 	CLOCK_BIT_CLR(reg_clk_en1, FLD_CLK0_UART3_EN);
 	CLOCK_BIT_CLR(reg_clk_en1, FLD_CLK1_DMA_EN);

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -350,9 +350,7 @@ void soc_early_init_hook(void)
 	analog_write_reg8(0x01, (analog_read_reg8(0x01) & 0xf8) | 0x06);
 #endif /*CONFIG_SOC_PMOS_SWITCH_TIME_CTL*/
 
-#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
-#endif /* CONFIG_PM */
 
 #if CONFIG_SOC_RISCV_TELINK_TL323X && CONFIG_ADC_TELINK_TL323X
 	g_adc_calib_flag = efuse_calib_sd_adc_vref();
@@ -526,9 +524,7 @@ void soc_tlx_restore(void)
 	analog_write_reg8(0x01, (analog_read_reg8(0x01) & 0xf8) | 0x06);
 #endif /*CONFIG_SOC_PMOS_SWITCH_TIME_CTL*/
 
-#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
-#endif /* CONFIG_PM */
 
 #if CONFIG_SOC_RISCV_TELINK_TL323X && CONFIG_ADC_TELINK_TL323X
 	if (g_adc_calib_flag == DRV_API_SUCCESS) {

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -563,7 +563,7 @@ void soc_tlx_restore(void)
 		PLL_192M_CCLK_48M_HCLK_24M_PCLK_12M_MSPI_48M;
 #if CONFIG_PM
 		pm_set_calib_0p925V_dig_ldo_voltage();
-		gen_fsk_close_unused_clock();
+		/* gen_fsk_close_unused_clock(); */
 #endif /* CONFIG_PM  */
 #elif CONFIG_SOC_RISCV_TELINK_TL721X
 #if CONFIG_PM

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -199,6 +199,7 @@ void soc_load_rf_parameters_deep_retention(void)
 #endif
 
 #if CONFIG_PM
+#define RST_BIT_SET(x, n)    ((x) |=~(n))
 #define RST_BIT_CLR(x, n)    ((x) &=~(n))
 #define CLOCK_BIT_CLR(x, n)    ((x) &=~(n))
 #if CONFIG_SOC_RISCV_TELINK_TL323X
@@ -207,28 +208,28 @@ void gen_fsk_close_unused_clock(void)
 {
 	RST_BIT_CLR(reg_rst0, FLD_RST0_I2C0);
 	/* comment because some user cases need UART1*/
-    /* RST_BIT_CLR(reg_rst0, FLD_RST0_UART1); */
+	/* RST_BIT_CLR(reg_rst0, FLD_RST0_UART1); */
 
-    RST_BIT_CLR(reg_rst1, FLD_RST1_UART3);
-    RST_BIT_CLR(reg_rst1, FLD_RST1_GSPI);
-    RST_BIT_CLR(reg_rst1, FLD_RST1_DMA);
-    RST_BIT_CLR(reg_rst1, FLD_RST1_SPISLV);
+	RST_BIT_CLR(reg_rst1, FLD_RST1_UART3);
+	RST_BIT_CLR(reg_rst1, FLD_RST1_GSPI);
+	RST_BIT_CLR(reg_rst1, FLD_RST1_DMA);
+	RST_BIT_CLR(reg_rst1, FLD_RST1_SPISLV);
 
-    RST_BIT_CLR(reg_rst2, FLD_RST2_I2C1);
+	RST_BIT_CLR(reg_rst2, FLD_RST2_I2C1);
 	RST_BIT_CLR(reg_rst2, FLD_RST2_TRNG);
 
-    RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC1);
+	RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC1);
 	RST_BIT_CLR(reg_rst3, FLD_RST3_BROM);
-    RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC);
+	RST_BIT_CLR(reg_rst3, FLD_RST3_QDEC);
 
-    RST_BIT_CLR(reg_rst4, FLD_RST4_UART4);
+	RST_BIT_CLR(reg_rst4, FLD_RST4_UART4);
 
-    RST_BIT_CLR(reg_rst5, FLD_RST5_UART2);
-    RST_BIT_CLR(reg_rst5, FLD_RST5_PEM);
+	RST_BIT_CLR(reg_rst5, FLD_RST5_UART2);
+	RST_BIT_CLR(reg_rst5, FLD_RST5_PEM);
 
-    RST_BIT_CLR(reg_rst6, FLD_RST6_RZ);
+	RST_BIT_CLR(reg_rst6, FLD_RST6_RZ);
 
-    RST_BIT_CLR(reg_rst7, FLD_RST7_USB1);
+	RST_BIT_CLR(reg_rst7, FLD_RST7_USB1);
 
 	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_LSPI_EN);
 	CLOCK_BIT_CLR(reg_clk_en0, FLD_CLK0_I2C0_EN);

--- a/soc/telink/tlsr/telink_tlx/soc_context.h
+++ b/soc/telink/tlsr/telink_tlx/soc_context.h
@@ -9,7 +9,7 @@
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 
-/* Telink B91 specific registers. */
+/* Telink specific registers. */
 #if defined(CONFIG_TELINK_TLX_PFT) && defined(CONFIG_ANDES_HWDSP)
 
 #define SOC_ESF_MEMBERS                                                                            \

--- a/soc/telink/tlsr/telink_w9x/debug.c
+++ b/soc/telink/tlsr/telink_w9x/debug.c
@@ -89,7 +89,7 @@ static void telink_w91_debug_init(void)
 			IRQ_CONNECT(UART_ISR_NUM + CONFIG_2ND_LVL_ISR_TBL_OFFSET, 0,
 				telink_w91_debug_isr, NULL, 0);
 			riscv_plic_set_priority(IRQ_TO_L2(UART_ISR_NUM) |
-							DT_IRQN(DT_INST(0, sifive_plic_1_0_0)),
+							DT_IRQN(DT_INST(0, telink_plic)),
 						1);
 		}
 		arch_irq_unlock(keys);
@@ -104,10 +104,10 @@ void telink_w91_debug_isr_set(bool enabled, void (*on_rx)(char c, void *ctx), vo
 		telink_w91_debug_isr_data.ctx = ctx;
 		__write_reg32(UART_BASE_ADDR + OFT_ATCUART_IER, (1 << 0));
 		riscv_plic_irq_enable(IRQ_TO_L2(UART_ISR_NUM) |
-				      DT_IRQN(DT_INST(0, sifive_plic_1_0_0)));
+				      DT_IRQN(DT_INST(0, telink_plic)));
 	} else {
 		riscv_plic_irq_disable(IRQ_TO_L2(UART_ISR_NUM) |
-				       DT_IRQN(DT_INST(0, sifive_plic_1_0_0)));
+				       DT_IRQN(DT_INST(0, telink_plic)));
 		__write_reg32(UART_BASE_ADDR + OFT_ATCUART_IER, 0);
 		telink_w91_debug_isr_data.on_rx = NULL;
 		telink_w91_debug_isr_data.ctx = NULL;

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: pull/191/head
+      revision: 566f129873adf045cecfceb7c8d22613b9f3079a
       path: modules/hal/telink
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: 64c1aba3df08fdfcd9a234e710096f76a0acf5a2
+      revision: pull/191/head
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
This PR combines multiple updates for Telink TL3238X:

1. Add PLIC interrupt controller suppor
2. Fix peripherals input pins in pinctrl driver
3. Fix pinctrl Kconfig to always disable GPIOs
4. Update clock management for TL3238X
5. Update hal_telink revision to include BLE SDK fixes ([#191](https://github.com/telink-semi/hal_telink/pull/191))
6. Update BLE SDK revision in CI workflows

Based on commits:
- 510db0b14f4d787aa041230f39a9eb20e1430d46 soc: telink: tlsr: telink_x: Kconfig: Always disable GPIOs
- 6b46cb54df2dd3dc3b4b5063d2d65d261ecad61b fix: resolve AES reentrancy issue.
- a4a122c215822353acbb4435984df8f549460ea3 drivers: pinctrl: telink_b9x: Fix peripherals input pins
- 2383bfa7d5ef20bdb1fc79a292690a9ac2cb10a3 soc: telink: add PLIC interrupt controller support
- 99b1ab86e1ce236913ca6959d0a0cfe39c570478 soc: tl3238x: update close clock