### PR TITLE
telink: tl3238x: add irq11 judgment for TL9268M

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -503,14 +503,12 @@ static void plic_irq_handler(const struct device *dev)
 	uint32_t cpu_id = arch_curr_cpu()->id;
 	/* Get the IRQ number generating the interrupt */
 	const uint32_t local_irq = sys_read32(claim_complete_addr);
-#if (CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION || CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION)
-	/* Workaround for Telink SOCs to aviod IRQ11 */
+	/* Telink SOCs to aviod IRQ11 */
 	if (!local_irq) {
 		extern void telink_zero_isr(void);
 		telink_zero_isr();
 		return;
 	}
-#endif /* CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION || CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
 
 #ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 	uint16_t *cpu_count = get_irq_hit_count_cpu(dev, cpu_id, local_irq);


### PR DESCRIPTION
 - Remove the retention define when run irq11 operation .