### PR TITLE
telink: tl3238x: fix compilation

### DIFF
--- a/soc/telink/tlsr/telink_b9x/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_b9x/CMakeLists.txt
@@ -28,7 +28,7 @@ zephyr_sources_ifdef(CONFIG_MCUBOOT_ACTION_HOOKS
 	mcuboot_status_change.c
 )
 
-zephyr_sources_ifdef(CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION
+zephyr_sources(
 	soc_irq0.c
 )
 

--- a/soc/telink/tlsr/telink_tlx/CMakeLists.txt
+++ b/soc/telink/tlsr/telink_tlx/CMakeLists.txt
@@ -36,7 +36,7 @@ zephyr_sources_ifdef(CONFIG_MCUBOOT_ACTION_HOOKS
 	mcuboot_status_change.c
 )
 
-zephyr_sources_ifdef(CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION
+zephyr_sources(
 	soc_irq0.c
 )
 


### PR DESCRIPTION
 - Import soc_irq0.c into the compilation chain .