### PR TITLE
west.yml: Update Telink TLx HAL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
       path: modules/hal/tdk
     - name: hal_telink
       url: https://github.com/telink-semi/hal_telink
-      revision: b70112010f8482ea9c476d2c702d40c100ddc95f
+      revision: 14c6149f6cc466c49d81e3b2f7f1e4d8ff6fbbb5
       path: modules/hal/telink
       groups:
         - hal


### PR DESCRIPTION
 - Update hal_v2 ble src/sdk.
 - Fix BLE init fails after PM is started.
 - Add tl5x skeleton.
 - Update tl323x early wakeup and adc process.