### PR TITLE
Revert "soc: telink: tlsr: telink_x: Kconfig: Always disable GPIOs"

### DIFF
--- a/drivers/pinctrl/pinctrl_b9x.c
+++ b/drivers/pinctrl/pinctrl_b9x.c
@@ -5,7 +5,9 @@
  */
 
 #include "analog.h"
+#if CONFIG_PM
 #include "gpio.h"
+#endif
 #include <zephyr/drivers/pinctrl.h>
 #if CONFIG_SOC_RISCV_TELINK_B91
 #include <zephyr/dt-bindings/pinctrl/b91-pinctrl.h>
@@ -222,7 +224,9 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 
 	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
 	pinctrl_b9x_gpio_function_disable(pin);
+#if CONFIG_PM
 	gpio_input_en(pin);
+#endif
 	/* set pull value */
 	pull = pull << offset;
 	analog_write_reg8(pull_up_en_addr, (analog_read_reg8(pull_up_en_addr) & mask) | pull);

--- a/drivers/pinctrl/pinctrl_tlx.c
+++ b/drivers/pinctrl/pinctrl_tlx.c
@@ -5,7 +5,9 @@
  */
 
 #include "analog.h"
+#if CONFIG_PM
 #include "gpio.h"
+#endif
 #include <zephyr/drivers/pinctrl.h>
 #if CONFIG_SOC_RISCV_TELINK_TL321X
 #include <zephyr/dt-bindings/pinctrl/tl321x-pinctrl.h>
@@ -207,7 +209,9 @@ static int pinctrl_configure_pin(const pinctrl_soc_pin_t *pinctrl)
 
 	/* disable GPIO function (can be enabled back by GPIO init using GPIO driver) */
 	pinctrl_tlx_gpio_function_disable(pin);
+#if CONFIG_PM
 	gpio_input_en(pin);
+#endif
 	/* set pull value */
 	pull = pull << offset;
 	analog_write_reg8(pull_up_en_addr, (analog_read_reg8(pull_up_en_addr) & mask) | pull);

--- a/soc/telink/tlsr/telink_b9x/soc.c
+++ b/soc/telink/tlsr/telink_b9x/soc.c
@@ -143,7 +143,9 @@ unsigned int cclk = DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency);
 	sys_init(POWER_MODE, VBAT_TYPE, GPIO_VOLTAGE_3V3);
 #endif
 
+#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
+#endif /* CONFIG_PM */
 
 #if (defined(CONFIG_BT_B9X) || defined(CONFIG_IEEE802154))
 	soc_load_rf_parameters_normal();
@@ -211,7 +213,9 @@ void soc_b9x_restore(void)
 	sys_init(POWER_MODE, VBAT_TYPE, GPIO_VOLTAGE_3V3);
 #endif
 
+#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
+#endif /* CONFIG_PM */
 
 #if (defined(CONFIG_BT_B9X) || defined(CONFIG_IEEE802154))
 	soc_load_rf_parameters_deep_retention();

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -145,7 +145,9 @@ void soc_early_init_hook(void)
 	pm_set_ret_ldo_voltage(RET_LDO_TRIM_0P65V);
 #endif
 
+#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
+#endif /* CONFIG_PM */
 
 #if (defined(CONFIG_BT_TLX) || defined(IEEE802154_TELINK_TLX))
 	soc_load_rf_parameters_normal();
@@ -217,7 +219,9 @@ void soc_tlx_restore(void)
 	/* system init */
 	sys_init(POWER_MODE, VBAT_TYPE, INTERNAL_CAP_XTAL24M);
 
+#if CONFIG_PM
 	gpio_shutdown(GPIO_ALL);
+#endif /* CONFIG_PM */
 
 #if (defined(CONFIG_BT_TLX) || defined(IEEE802154_TELINK_TLX))
 	soc_load_rf_parameters_deep_retention();


### PR DESCRIPTION
This reverts commit 510db0b14f4d787aa041230f39a9eb20e1430d46.
Revert GPIO shutdown change due to broken UART RX.