### PR TITLE
workflows: manifest: allow unsafe fork PR checkout

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -14,6 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: west setup
         env:


### PR DESCRIPTION
## Problem

The `Manifest` job fails on fork PRs (e.g. #791) with:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

For details: https://github.com/telink-semi/zephyr/actions/runs/30521370185/job/90802317907 


## Root cause

On 2026-07-20, `actions/checkout` backported its pwn-request protection from v7 to all supported floating major versions, including the `@v4` tag used by this workflow. The protection now refuses to check out fork PR head refs under `pull_request_target` by default, to prevent "pwn request" attacks.

Reference: https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target

## Why a separate PR is required

`pull_request_target` runs the workflow file from the **base branch**, not from the PR head. Therefore the fix cannot be applied through PR #791 itself — that PR's `Manifest` job will keep failing until the base branch (`release-v1.0-v4.1-branch`) carries the fix.

This PR applies the fix directly to the base branch so that fork PRs (including #791) can pass the `Manifest` check afterwards.

## Fix

Set `allow-unsafe-pr-checkout: true` on the `actions/checkout` step, as documented at https://gh.io/securely-using-pull_request_target.

## Security justification

This opt-in is safe here because the checked-out PR code is only inspected as data, never executed:

- `west init -l .` only parses `west.yml`
- `zephyrproject-rtos/action-manifest@v1.7.0` is a pinned third-party action that validates the manifest and applies labels — it does not execute any script, Makefile, or build command from the PR

No build, test, or script originating from the pull request is ever executed, satisfying the safety premise in GitHub's official guidance.

## Related

- Fixes the `Manifest` failure blocking #791
