### PR TITLE
bluetooth: host: investigate Telink legacy adv resume after disconnect

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1519,7 +1519,17 @@ void bt_le_adv_resume(void)
 		LOG_DBG("No valid legacy adv");
 		return;
 	}
-#if !CONFIG_SOC_FAMILY_TELINK_TLSR
+#if CONFIG_SOC_FAMILY_TELINK_TLSR
+	/* Telink controller does not keep BT_ADV_ENABLED in sync with the
+	 * controller state, so only rely on BT_ADV_PERSIST here. An explicit
+	 * bt_le_adv_stop() clears BT_ADV_PERSIST, which still prevents resuming
+	 * after a deliberate stop, while advertising implicitly paused by an
+	 * established connection can be resumed on disconnect for reconnection.
+	 */
+	if (!atomic_test_bit(adv->flags, BT_ADV_PERSIST)) {
+		return;
+	}
+#else
 	/* Connection is possible only in state adv-connectable.
 	 * After disconnect we are in state disconnected.
 	 * To make future connection possible we should set
@@ -1530,7 +1540,7 @@ void bt_le_adv_resume(void)
 	      !atomic_test_bit(adv->flags, BT_ADV_ENABLED))) {
 		return;
 	}
-#endif /* !CONFIG_SOC_FAMILY_TELINK_TLSR */
+#endif /* CONFIG_SOC_FAMILY_TELINK_TLSR */
 	if (!atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
 		return;
 	}


### PR DESCRIPTION
### Background

This is an issue that needs to be fixed in our Telink fork Zephyr.

On Telink TLSR SoCs (TL7218X), a BLE peripheral cannot be reconnected after
a disconnect when using legacy connectable advertising.

https://github.com/project-chip/connectedhomeip/pull/73510/changes/229070ad7b64076e907c4a53f4e69add05306ff2#r3805029716

### Information collected

From Andrii @andriy-bilynskyy (earlier debugging on B91):

The connection state transitions are:

    disconnected -> adv-connectable   (advertising)
    adv-connectable -> connected      (after connection)
    connected -> disconnect-complete  (after disconnection)
    disconnect-complete -> disconnected

The final `disconnected -> adv-connectable` transition never happens, so no
further connection is possible.

After disconnect, `bt_conn_unref()` triggers `bt_le_adv_resume()` in
`subsys/bluetooth/host/adv.c`. The guard

    if (!(atomic_test_bit(adv->flags, BT_ADV_PERSIST) &&
          !atomic_test_bit(adv->flags, BT_ADV_ENABLED))) {
        return;
    }

evaluates to "true" on Telink, so resume is skipped and the device stays
disconnected. Commenting out the whole guard fixes reconnection, but is a
hack. The flags need to be understood correctly since this is the common
vendor file.

From Zhihan  @strandingneko-vivi :

Suggested configuring the controller with
`blc_ll_configLegacyAdvEnableStrategy(LEG_ADV_EN_STRATEGY_2)` in the Telink
SDK during `bt_init`, instead of the default `LEG_ADV_EN_STRATEGY_3`.

### Experiments on TL7218X (peripheral_ht sample)

1) `LEG_ADV_EN_STRATEGY_2` + upstream `bt_le_adv_resume()` guard

   The connection stays in "connecting" and the host repeatedly logs:

       No pending conn for peer <addr> (random)
       Unable to look up conn with handle 64

   `STRATEGY_2` keeps advertising running regardless of connection state
   (only `blc_ll_setAdvEnable` controls it), which conflicts with Zephyr
   host's legacy-connectable state machine, so the host cannot match the
   `LE Connection Complete` event to a pending conn. Incompatible.

2) `LEG_ADV_EN_STRATEGY_3` + PERSIST-only resume guard (this branch)

   Connects once, but advertising is not resumed after disconnect. This
   reproduces Andrii's original observation. Skipping the unreliable
   `!BT_ADV_ENABLED` check does not help, so the root cause is not the resume
   guard itself but the host<->controller state sync after connect/disconnect
   under `STRATEGY_3`.

@strandingneko-vivi @Jackie-Kilby 
Please help investigate how to modify our Telink controller to match the Zephyr common Host.