### PR TITLE
ci: extend backport workflow for dev-tlk_v4.1 branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,7 @@ on:
       - labeled
     branches:
       - main
+      - dev-tlk_v*
 
 jobs:
   backport:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,7 @@ on:
       - labeled
     branches:
       - main
+      - develop
       - dev-tlk_v*
 
 jobs:

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -9,6 +9,7 @@ on:
       - synchronize
     branches:
       - v*-branch
+      - '*-v*-branch'
 
 jobs:
   backport:
@@ -17,7 +18,7 @@ jobs:
       group: backport-issue-check-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
-    if: github.repository == 'zephyrproject-rtos/zephyr'
+    if: github.repository == 'zephyrproject-rtos/zephyr' || github.repository == 'telink-semi/zephyr'
 
     steps:
       - name: Check out source code

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -9,7 +9,6 @@ on:
       - synchronize
     branches:
       - v*-branch
-      - '*-v*-branch'
 
 jobs:
   backport:
@@ -18,7 +17,7 @@ jobs:
       group: backport-issue-check-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
-    if: github.repository == 'zephyrproject-rtos/zephyr' || github.repository == 'telink-semi/zephyr'
+    if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
       - name: Check out source code


### PR DESCRIPTION
Enable the upstream `backport` GitHub Actions workflow for the Telink branch
scheme.

- Extends `.github/workflows/backport.yml` to also trigger on `develop` and
  `dev-tlk_v*` (in addition to `main`).
- After merge, adding a `backport <branch>` label to a merged PR automatically
  cherry-picks its commits and opens a backport PR to that branch
  (e.g. `backport release-v1.0-v4.1-branch`).
- Multiple `backport` labels are supported to backport to several branches.

Note: `backport_issue_check.yml` is intentionally left unchanged because this
fork does not use GitHub Issues.