### PR TITLE
west: update telink manifest and doc URLs for tl_ repo rename on develop_tlsr9268j_release_lighting

### DIFF
--- a/.github/workflows/telink-b91-build.yaml
+++ b/.github/workflows/telink-b91-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-b91-nds-build.yaml
+++ b/.github/workflows/telink-b91-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-b92-build.yaml
+++ b/.github/workflows/telink-b92-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-b92-nds-build.yaml
+++ b/.github/workflows/telink-b92-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-tl321x-build.yaml
+++ b/.github/workflows/telink-tl321x-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-tl321x-nds-build.yaml
+++ b/.github/workflows/telink-tl321x-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-tl721x-nds-build.yaml
+++ b/.github/workflows/telink-tl721x-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-w91-build.yaml
+++ b/.github/workflows/telink-w91-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-w91-nds-build.yaml
+++ b/.github/workflows/telink-w91-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/README.rst
+++ b/README.rst
@@ -39,47 +39,27 @@ and the documentation's `Getting Started Guide`_ to start developing.
 Telink Maintained Repositories
 ******************************
 
-Besides this repository, the SDK pulls in the following Telink maintained
-modules through its west manifests (``west.yml`` and
-``submanifests/telink.yaml``). They carry Telink specific modifications and
-optimizations on top of their upstream projects, or are Telink provided
-components, and are therefore published under the ``tl_`` naming convention:
+Besides this repository (``tl_zephyr``), the SDK pulls in the following Telink
+maintained modules through its west manifests (``west.yml`` and
+``submanifests/telink.yaml``). Forked repositories carry Telink-specific
+modifications and optimizations on top of upstream projects; others are Telink
+provided components. All forked modules are published under the ``tl_`` prefix
+to distinguish them from their upstreams:
 
-.. list-table::
-   :header-rows: 1
+- `tl_mcuboot`_ — fork of `MCUboot`_ with Telink boot-time optimizations
+- `tl_xz`_ — fork of `XZ Utils`_ integrated as a Zephyr module
+- `tl_openthread_libs`_ — Telink-provided prebuilt OpenThread FTD libraries
+- `hal_telink`_ — Telink HAL module (follows the upstream ``hal_<vendor>`` naming convention)
 
-   * - Repository
-     - Upstream
-     - Telink Modifications
-   * - `tl_mcuboot`_
-     - `MCUboot`_
-     - Boot time optimizations: the primary slot image is validated only on the first boot (``BOOT_VALIDATE_SLOT0_ONCE``); on TL323X the application image hash is computed directly from flash storage (``CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE``) without a RAM copy.
-   * - `tl_openthread`_
-     - `OpenThread`_
-     - Security fix for a MAC Key ID Mode 2 frame injection issue, and performance optimization placing the sleepy end device (SED) processing call tree (tasklets, timers, MAC frame handling, mesh forwarding) in the RAM code section (``OT_SED_RAM``) for faster execution on Telink SoCs.
-   * - `tl_xz`_
-     - `XZ Utils`_
-     - Zephyr module integration for ``liblzma`` (a ``zephyr/`` CMake and Kconfig wrapper) with size optimization (``-Os``) enabled by default.
-   * - `tl_openthread_libs`_
-     - Telink owned
-     - Prebuilt OpenThread FTD libraries for Telink SoCs, in extended and reduced feature set variants, linked as a Zephyr module when ``CONFIG_OPENTHREAD_TELINK_LIBRARY`` is selected.
+For details on each module, see the linked repositories.
 
-The Telink HAL module `hal_telink`_ keeps the upstream Zephyr HAL naming
-convention (``hal_<vendor>``). Other Telink provided components, such as the
-BLE SDK (``tl_ble_sdk_zephyr``), ``tflite-micro-telink`` and the NFC driver
-``nfc_st25dv``, keep their component oriented names and are referenced
-unchanged; all remaining manifest projects are consumed as-is from their
-upstream repositories.
-
-This repository and the modules listed above were previously published under
-their upstream-derived names (``zephyr``, ``mcuboot``, ``openthread``, ``xz``
-and ``openthread_telink_lib``) and have been renamed to carry the ``tl_``
-prefix, making the Telink maintained components of the SDK easy to identify.
+The modules above were previously published under their upstream-derived names
+(``zephyr``, ``mcuboot``, ``xz`` and ``openthread_telink_lib``)
+and have been renamed with the ``tl_`` prefix to make the Telink maintained
+components of the SDK easy to identify.
 
 .. _tl_mcuboot: https://github.com/telink-semi/tl_mcuboot
 .. _MCUboot: https://github.com/mcu-tools/mcuboot
-.. _tl_openthread: https://github.com/telink-semi/tl_openthread
-.. _OpenThread: https://github.com/openthread/openthread
 .. _tl_xz: https://github.com/telink-semi/tl_xz
 .. _XZ Utils: https://github.com/tukaani-project/xz
 .. _tl_openthread_libs: https://github.com/telink-semi/tl_openthread_libs

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,55 @@ Getting Started
 Welcome to Zephyr! See the `Introduction to Zephyr`_ for a high-level overview,
 and the documentation's `Getting Started Guide`_ to start developing.
 
+Telink Maintained Repositories
+******************************
+
+Besides this repository, the SDK pulls in the following Telink maintained
+modules through its west manifests (``west.yml`` and
+``submanifests/telink.yaml``). They carry Telink specific modifications and
+optimizations on top of their upstream projects, or are Telink provided
+components, and are therefore published under the ``tl_`` naming convention:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Repository
+     - Upstream
+     - Telink Modifications
+   * - `tl_mcuboot`_
+     - `MCUboot`_
+     - Boot time optimizations: the primary slot image is validated only on the first boot (``BOOT_VALIDATE_SLOT0_ONCE``); on TL323X the application image hash is computed directly from flash storage (``CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE``) without a RAM copy.
+   * - `tl_openthread`_
+     - `OpenThread`_
+     - Security fix for a MAC Key ID Mode 2 frame injection issue, and performance optimization placing the sleepy end device (SED) processing call tree (tasklets, timers, MAC frame handling, mesh forwarding) in the RAM code section (``OT_SED_RAM``) for faster execution on Telink SoCs.
+   * - `tl_xz`_
+     - `XZ Utils`_
+     - Zephyr module integration for ``liblzma`` (a ``zephyr/`` CMake and Kconfig wrapper) with size optimization (``-Os``) enabled by default.
+   * - `tl_openthread_libs`_
+     - Telink owned
+     - Prebuilt OpenThread FTD libraries for Telink SoCs, in extended and reduced feature set variants, linked as a Zephyr module when ``CONFIG_OPENTHREAD_TELINK_LIBRARY`` is selected.
+
+The Telink HAL module `hal_telink`_ keeps the upstream Zephyr HAL naming
+convention (``hal_<vendor>``). Other Telink provided components, such as the
+BLE SDK (``tl_ble_sdk_zephyr``), ``tflite-micro-telink`` and the NFC driver
+``nfc_st25dv``, keep their component oriented names and are referenced
+unchanged; all remaining manifest projects are consumed as-is from their
+upstream repositories.
+
+This repository and the modules listed above were previously published under
+their upstream-derived names (``zephyr``, ``mcuboot``, ``openthread``, ``xz``
+and ``openthread_telink_lib``) and have been renamed to carry the ``tl_``
+prefix, making the Telink maintained components of the SDK easy to identify.
+
+.. _tl_mcuboot: https://github.com/telink-semi/tl_mcuboot
+.. _MCUboot: https://github.com/mcu-tools/mcuboot
+.. _tl_openthread: https://github.com/telink-semi/tl_openthread
+.. _OpenThread: https://github.com/openthread/openthread
+.. _tl_xz: https://github.com/telink-semi/tl_xz
+.. _XZ Utils: https://github.com/tukaani-project/xz
+.. _tl_openthread_libs: https://github.com/telink-semi/tl_openthread_libs
+.. _hal_telink: https://github.com/telink-semi/hal_telink
+
 .. start_include_here
 
 Community Support

--- a/submanifests/telink.yaml
+++ b/submanifests/telink.yaml
@@ -4,12 +4,12 @@
 manifest:
   projects:
     - name: lzma
-      url: https://github.com/telink-semi/xz
+      url: https://github.com/telink-semi/tl_xz
       revision: 053c1629f452b43339e7cd5c66fc89a143f4827a
       path: modules/lib/lzma
 
     - name: openthread_telink_lib
-      url: https://github.com/telink-semi/openthread_telink_lib
+      url: https://github.com/telink-semi/tl_openthread_libs
       revision: tags/v4.1.1
       path: modules/lib/openthread_telink_lib
 

--- a/west.yml
+++ b/west.yml
@@ -302,7 +302,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      url: https://github.com/telink-semi/mcuboot
+      url: https://github.com/telink-semi/tl_mcuboot
       revision: efcdb99de1c7f778f0bbbf5dd4e53ecd745f101e
       path: bootloader/mcuboot
       groups:


### PR DESCRIPTION
## Summary

Update repository references for the `tl_` repo rename, phase 1 (UTCSH-526 / Rename-01, parent epic UTCSH-525).

| Old | New |
|---|---|
| `telink-semi/zephyr` | `telink-semi/tl_zephyr` |
| `telink-semi/mcuboot` | `telink-semi/tl_mcuboot` |
| `telink-semi/openthread` | `telink-semi/tl_openthread` |
| `telink-semi/xz` | `telink-semi/tl_xz` |
| `telink-semi/openthread_telink_lib` | `telink-semi/tl_openthread_libs` (placeholder first) |


Notes:
- `openthread_telink_lib` uses a placeholder-first strategy: `tl_openthread_libs` is published as a mirror snapshot **before** this PR merges, so the new URL is live immediately; the original repository is renamed onto that name after ThreadGroup confirmation (UTCSH-533 / Rename-08). The west project `name` and local `path` (`modules/lib/openthread_telink_lib`) stay unchanged — only the manifest `url` changes.
- Historical release notes are left unchanged (GitHub 301 redirects cover them).

## Changes

- `west.yml` / `submanifests/*.yaml`: manifest URLs and `repo-path` entries
- `.github/workflows/`: CI clone/fetch URLs
- README / docs: repository links

## Merge timing

> [!WARNING]
> Do NOT merge before the freeze window. CI cloning `tl_*.git` URLs fails until the GitHub-side renames are executed (UTCSH-527 / Rename-02, UTCSH-528 / Rename-03). Exception: `tl_openthread_libs` is already live as a placeholder mirror, so that URL works before the freeze window.

## Verification

- [ ] CI green after the GitHub-side rename is executed
- [ ] `west update` succeeds with the updated manifest
- [ ] `west update` fetches `tl_openthread_libs` (placeholder mirror) via the updated submanifest
- [ ] No remaining `telink-semi/{zephyr,mcuboot,openthread,xz,openthread_telink_lib}` references outside release notes

Tracking: UTCSH-525 (epic) / UTCSH-526 (Rename-01)
